### PR TITLE
Support upstream Codex 0.122.0

### DIFF
--- a/patches/codex-hot-reload-tests-0.122.patch
+++ b/patches/codex-hot-reload-tests-0.122.patch
@@ -1,0 +1,681 @@
+diff --git a/codex-rs/core/src/client_tests.rs b/codex-rs/core/src/client_tests.rs
+index 357a892..d71c0b3 100644
+--- a/codex-rs/core/src/client_tests.rs
++++ b/codex-rs/core/src/client_tests.rs
+@@ -17,6 +17,7 @@ use crate::agent_identity::StoredAgentIdentity;
+ use base64::Engine as _;
+ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+ use codex_app_server_protocol::AuthMode;
++use codex_config::types::AuthCredentialsStoreMode;
+ use codex_login::AuthManager;
+ use codex_login::CodexAuth;
+ use codex_model_provider::BearerAuthProvider;
+@@ -38,6 +39,7 @@ use futures::StreamExt;
+ use pretty_assertions::assert_eq;
+ use serde::Deserialize;
+ use serde_json::json;
++use std::path::Path;
+ use tempfile::TempDir;
+ 
+ fn test_model_client(session_source: SessionSource) -> ModelClient {
+@@ -55,6 +57,43 @@ fn test_model_client(session_source: SessionSource) -> ModelClient {
+     )
+ }
+ 
++#[expect(clippy::unwrap_used)]
++fn write_chatgpt_auth_json(codex_home: &Path, access_token: &str, account_id: &str) {
++    let header = json!({ "alg": "none", "typ": "JWT" });
++    let payload = json!({
++        "email": "user@example.com",
++        "https://api.openai.com/auth": {
++            "chatgpt_plan_type": "plus",
++            "chatgpt_account_id": account_id
++        }
++    });
++    let b64 = |bytes: &[u8]| URL_SAFE_NO_PAD.encode(bytes);
++    let fake_jwt = format!(
++        "{}.{}.{}",
++        b64(&serde_json::to_vec(&header).unwrap()),
++        b64(&serde_json::to_vec(&payload).unwrap()),
++        b64(b"sig")
++    );
++
++    let auth_json = json!({
++        "auth_mode": "chatgpt",
++        "OPENAI_API_KEY": null,
++        "tokens": {
++            "id_token": fake_jwt,
++            "access_token": access_token,
++            "refresh_token": "refresh-test",
++            "account_id": account_id
++        },
++        "last_refresh": chrono::Utc::now(),
++    });
++
++    std::fs::write(
++        codex_home.join("auth.json"),
++        serde_json::to_string_pretty(&auth_json).unwrap(),
++    )
++    .unwrap();
++}
++
+ fn test_model_info() -> ModelInfo {
+     serde_json::from_value(json!({
+         "slug": "gpt-test",
+@@ -429,3 +468,57 @@ async fn websocket_agent_task_bypasses_cached_bearer_prewarm() {
+ 
+     server.shutdown().await;
+ }
++
++#[tokio::test]
++async fn current_client_setup_reloads_auth_from_disk_between_turns() {
++    let codex_home = TempDir::new().expect("tempdir");
++    write_chatgpt_auth_json(codex_home.path(), "token-one", "acc-one");
++
++    let provider = create_oss_provider_with_base_url("https://example.com/v1", WireApi::Responses);
++    let auth = CodexAuth::from_auth_storage(codex_home.path(), AuthCredentialsStoreMode::File)
++        .expect("load auth")
++        .expect("auth exists");
++    let auth_manager =
++        crate::test_support::auth_manager_from_auth_with_home(auth, codex_home.path().to_path_buf());
++    let client = ModelClient::new(
++        Some(auth_manager),
++        ThreadId::new(),
++        /*installation_id*/ "11111111-1111-4111-8111-111111111111".to_string(),
++        provider,
++        SessionSource::Cli,
++        /*model_verbosity*/ None,
++        /*enable_request_compression*/ false,
++        /*include_timing_metrics*/ false,
++        /*beta_features_header*/ None,
++    );
++
++    let first = client
++        .current_client_setup(/*agent_task*/ None)
++        .await
++        .expect("first client setup");
++    assert_eq!(
++        first
++            .auth
++            .as_ref()
++            .and_then(|auth| auth.get_token().ok())
++            .as_deref(),
++        Some("token-one")
++    );
++    assert!(!first.auth_connection_changed);
++
++    write_chatgpt_auth_json(codex_home.path(), "token-two", "acc-two");
++
++    let second = client
++        .current_client_setup(/*agent_task*/ None)
++        .await
++        .expect("second client setup");
++    assert_eq!(
++        second
++            .auth
++            .as_ref()
++            .and_then(|auth| auth.get_token().ok())
++            .as_deref(),
++        Some("token-two")
++    );
++    assert!(second.auth_connection_changed);
++}
+diff --git a/codex-rs/core/tests/common/responses.rs b/codex-rs/core/tests/common/responses.rs
+index 8def3ac..92c62f5 100644
+--- a/codex-rs/core/tests/common/responses.rs
++++ b/codex-rs/core/tests/common/responses.rs
+@@ -3,6 +3,8 @@
+ use std::collections::VecDeque;
+ use std::sync::Arc;
+ use std::sync::Mutex;
++use std::sync::atomic::AtomicBool;
++use std::sync::atomic::Ordering;
+ use std::time::Duration;
+ 
+ use anyhow::Result;
+@@ -16,6 +18,8 @@ use serde_json::Value;
+ use tokio::net::TcpListener;
+ use tokio::sync::Notify;
+ use tokio::sync::oneshot;
++use tokio::sync::watch;
++use tokio::task::JoinSet;
+ use tokio_tungstenite::accept_hdr_async_with_config;
+ use tokio_tungstenite::tungstenite::Message;
+ use tokio_tungstenite::tungstenite::extensions::ExtensionsConfig;
+@@ -1261,16 +1265,23 @@ pub async fn start_websocket_server_with_headers(
+     let request_log = Arc::clone(&request_log_updated);
+     let connections = Arc::new(Mutex::new(VecDeque::from(connections)));
+     let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
++    let shutdown_state = Arc::new(AtomicBool::new(false));
++    let (shutdown_watch_tx, shutdown_watch_rx) = watch::channel(false);
+ 
+     let task = tokio::spawn(async move {
++        let mut connection_tasks = JoinSet::new();
+         loop {
+             let accept_res = tokio::select! {
+-                _ = &mut shutdown_rx => return,
++                _ = &mut shutdown_rx => {
++                    shutdown_state.store(true, Ordering::SeqCst);
++                    let _ = shutdown_watch_tx.send(true);
++                    break;
++                },
+                 accept_res = listener.accept() => accept_res,
+             };
+             let (stream, _) = match accept_res {
+                 Ok(value) => value,
+-                Err(_) => return,
++                Err(_) => break,
+             };
+             let connection = {
+                 let mut pending = connections.lock().unwrap();
+@@ -1281,132 +1292,152 @@ pub async fn start_websocket_server_with_headers(
+                 continue;
+             };
+ 
+-            if let Some(delay) = connection.accept_delay {
+-                tokio::time::sleep(delay).await;
+-            }
+-
+             let response_headers = connection.response_headers.clone();
+             let handshake_log = Arc::clone(&handshakes);
+-            let callback = move |req: &Request, mut response: Response| {
+-                let headers = req
+-                    .headers()
+-                    .iter()
+-                    .filter_map(|(name, value)| {
+-                        value
+-                            .to_str()
+-                            .ok()
+-                            .map(|value| (name.as_str().to_string(), value.to_string()))
+-                    })
+-                    .collect();
+-                handshake_log.lock().unwrap().push(WebSocketHandshake {
+-                    uri: req.uri().to_string(),
+-                    headers,
+-                });
+-
+-                let headers_mut = response.headers_mut();
+-                for (name, value) in &response_headers {
+-                    if let (Ok(name), Ok(value)) = (
+-                        HeaderName::from_bytes(name.as_bytes()),
+-                        HeaderValue::from_str(value),
+-                    ) {
+-                        headers_mut.insert(name, value);
+-                    }
++            let requests = Arc::clone(&requests);
++            let request_log = Arc::clone(&request_log);
++            let start = start;
++            let shutdown_state = Arc::clone(&shutdown_state);
++            let mut shutdown_watch = shutdown_watch_rx.clone();
++
++            connection_tasks.spawn(async move {
++                if let Some(delay) = connection.accept_delay {
++                    tokio::time::sleep(delay).await;
+                 }
+ 
+-                Ok(response)
+-            };
++                let callback = move |req: &Request, mut response: Response| {
++                    let headers = req
++                        .headers()
++                        .iter()
++                        .filter_map(|(name, value)| {
++                            value
++                                .to_str()
++                                .ok()
++                                .map(|value| (name.as_str().to_string(), value.to_string()))
++                        })
++                        .collect();
++                    handshake_log.lock().unwrap().push(WebSocketHandshake {
++                        uri: req.uri().to_string(),
++                        headers,
++                    });
++
++                    let headers_mut = response.headers_mut();
++                    for (name, value) in &response_headers {
++                        if let (Ok(name), Ok(value)) = (
++                            HeaderName::from_bytes(name.as_bytes()),
++                            HeaderValue::from_str(value),
++                        ) {
++                            headers_mut.insert(name, value);
++                        }
++                    }
+ 
+-            let mut ws_stream = match accept_hdr_async_with_config(
+-                stream,
+-                callback,
+-                Some(websocket_accept_config()),
+-            )
+-            .await
+-            {
+-                Ok(ws) => ws,
+-                Err(_) => continue,
+-            };
++                    Ok(response)
++                };
+ 
+-            let connection_index = {
+-                let mut log = requests.lock().unwrap();
+-                log.push(Vec::new());
+-                log.len() - 1
+-            };
+-            let close_after_requests = connection.close_after_requests;
+-            for request_events in connection.requests {
+-                let Some(Ok(message)) = ws_stream.next().await else {
+-                    break;
++                let mut ws_stream = match accept_hdr_async_with_config(
++                    stream,
++                    callback,
++                    Some(websocket_accept_config()),
++                )
++                .await
++                {
++                    Ok(ws) => ws,
++                    Err(_) => return,
+                 };
+-                if let Some(body) = parse_ws_request_body(message) {
+-                    let mut log = requests.lock().unwrap();
+-                    if let Some(connection_log) = log.get_mut(connection_index) {
+-                        connection_log.push(WebSocketRequest { body });
+-                        let request_index = connection_log.len() - 1;
+-                        let request = &connection_log[request_index];
+-                        let request_body = request.body_json();
+-                        eprintln!(
+-                            "[ws test server +{}ms] connection={} received request={} type={:?} role={:?} text={:?} data={:?}",
+-                            start.elapsed().as_millis(),
+-                            connection_index,
+-                            request_index,
+-                            request_body.get("type").and_then(Value::as_str),
+-                            request_body
+-                                .get("item")
+-                                .and_then(|item| item.get("role"))
+-                                .and_then(Value::as_str),
+-                            request_body
+-                                .get("item")
+-                                .and_then(|item| item.get("content"))
+-                                .and_then(Value::as_array)
+-                                .and_then(|content| content.first())
+-                                .and_then(|content| content.get("text"))
+-                                .and_then(Value::as_str),
+-                            request_body
+-                                .get("item")
+-                                .and_then(|item| item.get("content"))
+-                                .and_then(Value::as_array)
+-                                .and_then(|content| content.first())
+-                                .and_then(|content| content.get("data"))
+-                                .and_then(Value::as_str),
+-                        );
+-                    }
+-                    request_log.notify_waiters();
+-                }
+ 
+-                eprintln!(
+-                    "[ws test server +{}ms] connection={} sending batch_size={} event_types={:?} audio_data={:?}",
+-                    start.elapsed().as_millis(),
+-                    connection_index,
+-                    request_events.len(),
+-                    request_events
+-                        .iter()
+-                        .map(|event| event.get("type").and_then(Value::as_str))
+-                        .collect::<Vec<_>>(),
+-                    request_events
+-                        .iter()
+-                        .find_map(|event| event.get("delta").and_then(Value::as_str)),
+-                );
+-                for event in &request_events {
+-                    let Ok(payload) = serde_json::to_string(event) else {
+-                        continue;
++                let connection_index = {
++                    let mut log = requests.lock().unwrap();
++                    log.push(Vec::new());
++                    log.len() - 1
++                };
++                let close_after_requests = connection.close_after_requests;
++                for request_events in connection.requests {
++                    let message = if close_after_requests || *shutdown_watch.borrow() {
++                        ws_stream.next().await
++                    } else {
++                        tokio::select! {
++                            message = ws_stream.next() => message,
++                            changed = shutdown_watch.changed() => {
++                                let _ = changed;
++                                None
++                            }
++                        }
+                     };
+-                    if ws_stream.send(Message::Text(payload.into())).await.is_err() {
++                    let Some(Ok(message)) = message else {
+                         break;
++                    };
++                    if let Some(body) = parse_ws_request_body(message) {
++                        let mut log = requests.lock().unwrap();
++                        if let Some(connection_log) = log.get_mut(connection_index) {
++                            connection_log.push(WebSocketRequest { body });
++                            let request_index = connection_log.len() - 1;
++                            let request = &connection_log[request_index];
++                            let request_body = request.body_json();
++                            eprintln!(
++                                "[ws test server +{}ms] connection={} received request={} type={:?} role={:?} text={:?} data={:?}",
++                                start.elapsed().as_millis(),
++                                connection_index,
++                                request_index,
++                                request_body.get("type").and_then(Value::as_str),
++                                request_body
++                                    .get("item")
++                                    .and_then(|item| item.get("role"))
++                                    .and_then(Value::as_str),
++                                request_body
++                                    .get("item")
++                                    .and_then(|item| item.get("content"))
++                                    .and_then(Value::as_array)
++                                    .and_then(|content| content.first())
++                                    .and_then(|content| content.get("text"))
++                                    .and_then(Value::as_str),
++                                request_body
++                                    .get("item")
++                                    .and_then(|item| item.get("content"))
++                                    .and_then(Value::as_array)
++                                    .and_then(|content| content.first())
++                                    .and_then(|content| content.get("data"))
++                                    .and_then(Value::as_str),
++                            );
++                        }
++                        request_log.notify_waiters();
+                     }
+-                }
+-            }
+ 
+-            if close_after_requests {
+-                let _ = ws_stream.close(None).await;
+-            } else {
+-                let _ = shutdown_rx.await;
+-                return;
+-            }
++                    eprintln!(
++                        "[ws test server +{}ms] connection={} sending batch_size={} event_types={:?} audio_data={:?}",
++                        start.elapsed().as_millis(),
++                        connection_index,
++                        request_events.len(),
++                        request_events
++                            .iter()
++                            .map(|event| event.get("type").and_then(Value::as_str))
++                            .collect::<Vec<_>>(),
++                        request_events
++                            .iter()
++                            .find_map(|event| event.get("delta").and_then(Value::as_str)),
++                    );
++                    for event in &request_events {
++                        let Ok(payload) = serde_json::to_string(event) else {
++                            continue;
++                        };
++                        if ws_stream.send(Message::Text(payload.into())).await.is_err() {
++                            break;
++                        }
++                    }
++                }
+ 
+-            if connections.lock().unwrap().is_empty() {
+-                return;
+-            }
++                if close_after_requests {
++                    let _ = ws_stream.close(None).await;
++                } else if !shutdown_state.load(Ordering::SeqCst) {
++                    while !*shutdown_watch.borrow() {
++                        if shutdown_watch.changed().await.is_err() {
++                            break;
++                        }
++                    }
++                }
++            });
+         }
++
++        while connection_tasks.join_next().await.is_some() {}
+     });
+ 
+     WebSocketTestServer {
+diff --git a/codex-rs/core/tests/suite/client_websockets.rs b/codex-rs/core/tests/suite/client_websockets.rs
+index 07f9f58..d22c33f 100644
+--- a/codex-rs/core/tests/suite/client_websockets.rs
++++ b/codex-rs/core/tests/suite/client_websockets.rs
+@@ -1,6 +1,7 @@
+ #![allow(clippy::expect_used, clippy::unwrap_used)]
+ use codex_api::WS_REQUEST_HEADER_TRACEPARENT_CLIENT_METADATA_KEY;
+ use codex_api::WS_REQUEST_HEADER_TRACESTATE_CLIENT_METADATA_KEY;
++use codex_config::types::AuthCredentialsStoreMode;
+ use codex_core::ModelClient;
+ use codex_core::ModelClientSession;
+ use codex_core::Prompt;
+@@ -45,6 +46,8 @@ use futures::StreamExt;
+ use opentelemetry_sdk::metrics::InMemoryMetricExporter;
+ use pretty_assertions::assert_eq;
+ use serde_json::json;
++use std::path::Path;
++use std::path::PathBuf;
+ use std::sync::Arc;
+ use std::time::Duration;
+ use tempfile::TempDir;
+@@ -85,6 +88,7 @@ fn assert_request_trace_matches(body: &serde_json::Value, expected_trace: &W3cTr
+ 
+ struct WebsocketTestHarness {
+     _codex_home: TempDir,
++    codex_home_path: PathBuf,
+     client: ModelClient,
+     conversation_id: ThreadId,
+     model_info: ModelInfo,
+@@ -93,6 +97,46 @@ struct WebsocketTestHarness {
+     session_telemetry: SessionTelemetry,
+ }
+ 
++#[expect(clippy::unwrap_used)]
++fn write_chatgpt_auth_json(codex_home: &Path, access_token: &str, account_id: &str) {
++    use base64::Engine as _;
++
++    let header = json!({ "alg": "none", "typ": "JWT" });
++    let payload = json!({
++        "email": "user@example.com",
++        "https://api.openai.com/auth": {
++            "chatgpt_plan_type": "plus",
++            "chatgpt_account_id": account_id,
++        }
++    });
++
++    let b64 = |bytes: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
++    let fake_jwt = format!(
++        "{}.{}.{}",
++        b64(&serde_json::to_vec(&header).unwrap()),
++        b64(&serde_json::to_vec(&payload).unwrap()),
++        b64(b"sig")
++    );
++
++    let auth_json = json!({
++        "auth_mode": "chatgpt",
++        "OPENAI_API_KEY": null,
++        "tokens": {
++            "id_token": fake_jwt,
++            "access_token": access_token,
++            "refresh_token": "refresh-test",
++            "account_id": account_id,
++        },
++        "last_refresh": chrono::Utc::now(),
++    });
++
++    std::fs::write(
++        codex_home.join("auth.json"),
++        serde_json::to_string_pretty(&auth_json).unwrap(),
++    )
++    .unwrap();
++}
++
+ #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+ async fn responses_websocket_streams_request() {
+     skip_if_no_network!();
+@@ -364,6 +408,75 @@ async fn responses_websocket_reuses_connection_after_session_drop() {
+     server.shutdown().await;
+ }
+ 
++#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
++async fn responses_websocket_reconnects_when_auth_snapshot_changes_between_turns() {
++    skip_if_no_network!();
++
++    let server = start_websocket_server_with_headers(vec![
++        WebSocketConnectionConfig {
++            requests: vec![
++                vec![ev_response_created("resp-1"), ev_completed("resp-1")],
++                vec![
++                    ev_response_created("resp-reused"),
++                    ev_completed("resp-reused"),
++                ],
++            ],
++            response_headers: Vec::new(),
++            accept_delay: None,
++            close_after_requests: false,
++        },
++        WebSocketConnectionConfig {
++            requests: vec![vec![ev_response_created("resp-2"), ev_completed("resp-2")]],
++            response_headers: Vec::new(),
++            accept_delay: None,
++            close_after_requests: false,
++        },
++    ])
++    .await;
++
++    let harness = authenticated_websocket_harness(&server).await;
++    let prompt_one = prompt_with_input(vec![message_item("hello")]);
++    let prompt_two = prompt_with_input(vec![message_item("switched")]);
++
++    let mut first_turn = harness.client.new_session();
++    tokio::time::timeout(
++        Duration::from_secs(5),
++        stream_until_complete(&mut first_turn, &harness, &prompt_one),
++    )
++    .await
++    .expect("first authenticated websocket turn timed out");
++    assert!(
++        server.wait_for_handshakes(1, Duration::from_secs(1)).await,
++        "expected first websocket handshake",
++    );
++
++    write_chatgpt_auth_json(&harness.codex_home_path, "token-two", "acc-two");
++
++    let mut second_turn = harness.client.new_session();
++    tokio::time::timeout(
++        Duration::from_secs(5),
++        stream_until_complete(&mut second_turn, &harness, &prompt_two),
++    )
++    .await
++    .expect("second authenticated websocket turn timed out");
++    assert!(
++        server.wait_for_handshakes(2, Duration::from_secs(1)).await,
++        "expected websocket reconnect after auth snapshot change",
++    );
++
++    assert_eq!(server.handshakes().len(), 2);
++    assert_eq!(
++        server.handshakes()[0].header("authorization").as_deref(),
++        Some("Bearer token-one")
++    );
++    assert_eq!(
++        server.handshakes()[1].header("authorization").as_deref(),
++        Some("Bearer token-two")
++    );
++
++    server.shutdown().await;
++}
++
+ #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+ async fn responses_websocket_preconnect_is_reused_even_with_header_changes() {
+     skip_if_no_network!();
+@@ -1725,6 +1838,12 @@ fn websocket_provider(server: &WebSocketTestServer) -> ModelProviderInfo {
+     websocket_provider_with_connect_timeout(server, /*websocket_connect_timeout_ms*/ None)
+ }
+ 
++fn authenticated_websocket_provider(server: &WebSocketTestServer) -> ModelProviderInfo {
++    let mut provider = websocket_provider(server);
++    provider.requires_openai_auth = true;
++    provider
++}
++
+ fn websocket_provider_with_connect_timeout(
+     server: &WebSocketTestServer,
+     websocket_connect_timeout_ms: Option<u64>,
+@@ -1775,11 +1894,37 @@ async fn websocket_harness_with_options(
+         .await
+ }
+ 
++async fn authenticated_websocket_harness(server: &WebSocketTestServer) -> WebsocketTestHarness {
++    let codex_home = TempDir::new().unwrap();
++    write_chatgpt_auth_json(codex_home.path(), "token-one", "acc-one");
++    websocket_harness_with_provider_options_and_home(
++        authenticated_websocket_provider(server),
++        /*runtime_metrics_enabled*/ false,
++        codex_home,
++        /*use_auth_from_home*/ true,
++    )
++    .await
++}
++
+ async fn websocket_harness_with_provider_options(
+     provider: ModelProviderInfo,
+     runtime_metrics_enabled: bool,
+ ) -> WebsocketTestHarness {
+-    let codex_home = TempDir::new().unwrap();
++    websocket_harness_with_provider_options_and_home(
++        provider,
++        runtime_metrics_enabled,
++        TempDir::new().unwrap(),
++        /*use_auth_from_home*/ false,
++    )
++    .await
++}
++
++async fn websocket_harness_with_provider_options_and_home(
++    provider: ModelProviderInfo,
++    runtime_metrics_enabled: bool,
++    codex_home: TempDir,
++    use_auth_from_home: bool,
++) -> WebsocketTestHarness {
+     let mut config = load_default_config_for_test(&codex_home).await;
+     config.model = Some(MODEL.to_string());
+     if runtime_metrics_enabled {
+@@ -1791,8 +1936,20 @@ async fn websocket_harness_with_provider_options(
+     let config = Arc::new(config);
+     let model_info = codex_core::test_support::construct_model_info_offline(MODEL, &config);
+     let conversation_id = ThreadId::new();
+-    let auth_manager =
+-        codex_core::test_support::auth_manager_from_auth(CodexAuth::from_api_key("Test API Key"));
++    let auth_manager = if use_auth_from_home {
++        let auth =
++            match CodexAuth::from_auth_storage(codex_home.path(), AuthCredentialsStoreMode::File) {
++                Ok(Some(auth)) => auth,
++                Ok(None) => panic!("No CodexAuth found in codex_home"),
++                Err(err) => panic!("Failed to load auth from codex_home: {err}"),
++            };
++        codex_core::test_support::auth_manager_from_auth_with_home(
++            auth,
++            codex_home.path().to_path_buf(),
++        )
++    } else {
++        codex_core::test_support::auth_manager_from_auth(CodexAuth::from_api_key("Test API Key"))
++    };
+     let exporter = InMemoryMetricExporter::default();
+     let metrics = MetricsClient::new(
+         MetricsConfig::in_memory("test", "codex-core", env!("CARGO_PKG_VERSION"), exporter)
+@@ -1814,8 +1971,9 @@ async fn websocket_harness_with_provider_options(
+     .with_metrics(metrics);
+     let effort = None;
+     let summary = ReasoningSummary::Auto;
++    let codex_home_path = codex_home.path().to_path_buf();
+     let client = ModelClient::new(
+-        /*auth_manager*/ None,
++        /*auth_manager*/ use_auth_from_home.then_some(auth_manager.clone()),
+         conversation_id,
+         /*installation_id*/ TEST_INSTALLATION_ID.to_string(),
+         provider.clone(),
+@@ -1828,6 +1986,7 @@ async fn websocket_harness_with_provider_options(
+ 
+     WebsocketTestHarness {
+         _codex_home: codex_home,
++        codex_home_path,
+         client,
+         conversation_id,
+         model_info,

--- a/src/lib/maintained-patch.js
+++ b/src/lib/maintained-patch.js
@@ -5,24 +5,46 @@ import path from "node:path";
 const CLIENT_RELATIVE_PATH = path.join("codex-rs", "core", "src", "client.rs");
 const TEST_SUITE_MOD_RELATIVE_PATH = path.join("codex-rs", "core", "tests", "suite", "mod.rs");
 const TEST_BINARY_SUPPORT_RELATIVE_PATH = path.join("codex-rs", "test-binary-support", "lib.rs");
-const TEST_FALLBACK_PATCH = path.join("patches", "codex-hot-reload-tests.patch");
+const TEST_FALLBACK_PATCHES = [
+  path.join("patches", "codex-hot-reload-tests.patch"),
+  path.join("patches", "codex-hot-reload-tests-0.122.patch"),
+];
 
 const CLIENT_RUNTIME_REWRITES = [
   {
     id: "current-client-setup-field",
-    search: `struct CurrentClientSetup {
+    variants: [
+      {
+        search: `struct CurrentClientSetup {
     auth: Option<CodexAuth>,
     api_provider: codex_api::Provider,
     api_auth: CoreAuthProvider,
 }
 `,
-    replacement: `struct CurrentClientSetup {
+        replacement: `struct CurrentClientSetup {
     auth: Option<CodexAuth>,
     api_provider: codex_api::Provider,
     api_auth: CoreAuthProvider,
     auth_connection_changed: bool,
 }
 `,
+      },
+      {
+        search: `struct CurrentClientSetup {
+    auth: Option<CodexAuth>,
+    api_provider: ApiProvider,
+    api_auth: SharedAuthProvider,
+}
+`,
+        replacement: `struct CurrentClientSetup {
+    auth: Option<CodexAuth>,
+    api_provider: ApiProvider,
+    api_auth: SharedAuthProvider,
+    auth_connection_changed: bool,
+}
+`,
+      },
+    ],
   },
   {
     id: "auth-connection-key-helper",
@@ -52,7 +74,9 @@ fn auth_connection_key(auth: Option<&CodexAuth>) -> Option<AuthConnectionKey> {
   },
   {
     id: "current-client-setup-reload",
-    search: `    async fn current_client_setup(&self) -> Result<CurrentClientSetup> {
+    variants: [
+      {
+        search: `    async fn current_client_setup(&self) -> Result<CurrentClientSetup> {
         let auth = match self.state.auth_manager.as_ref() {
             Some(manager) => manager.auth().await,
             None => None,
@@ -69,7 +93,7 @@ fn auth_connection_key(auth: Option<&CodexAuth>) -> Option<AuthConnectionKey> {
         })
     }
 `,
-    replacement: `    async fn current_client_setup(&self) -> Result<CurrentClientSetup> {
+        replacement: `    async fn current_client_setup(&self) -> Result<CurrentClientSetup> {
         let (auth, auth_connection_changed) = match self.state.auth_manager.as_ref() {
             Some(manager) => {
                 let cached_before_reload = auth_connection_key(manager.auth_cached().as_ref());
@@ -94,10 +118,121 @@ fn auth_connection_key(auth: Option<&CodexAuth>) -> Option<AuthConnectionKey> {
         })
     }
 `,
+      },
+      {
+        search: `    async fn current_client_setup(
+        &self,
+        agent_task: Option<&RegisteredAgentTask>,
+    ) -> Result<CurrentClientSetup> {
+        let auth = self.state.provider.auth().await;
+        let api_provider = self.state.provider.api_provider().await?;
+        let auth_manager = self.state.provider.auth_manager();
+        let api_auth = match (agent_task, auth_manager.as_ref(), auth.as_ref()) {
+            (Some(agent_task), Some(auth_manager), Some(auth)) => {
+                if let Some(authorization_header_value) = auth_manager
+                    .chatgpt_agent_task_authorization_header_for_auth(
+                        auth,
+                        agent_task.authorization_target(),
+                    )
+                    .map_err(|err| {
+                        CodexErr::Stream(
+                            format!("failed to build agent assertion authorization: {err}"),
+                            None,
+                        )
+                    })?
+                {
+                    debug!(
+                        agent_runtime_id = %agent_task.agent_runtime_id,
+                        task_id = %agent_task.task_id,
+                        "using agent assertion authorization for downstream request"
+                    );
+                    let mut auth_provider = AuthorizationHeaderAuthProvider::new(
+                        Some(authorization_header_value),
+                        /*account_id*/ None,
+                    );
+                    if auth.is_fedramp_account() {
+                        auth_provider = auth_provider.with_fedramp_routing_header();
+                    }
+                    Arc::new(auth_provider)
+                } else {
+                    self.state.provider.api_auth().await?
+                }
+            }
+            _ => self.state.provider.api_auth().await?,
+        };
+        Ok(CurrentClientSetup {
+            auth,
+            api_provider,
+            api_auth,
+        })
+    }
+`,
+        replacement: `    async fn current_client_setup(
+        &self,
+        agent_task: Option<&RegisteredAgentTask>,
+    ) -> Result<CurrentClientSetup> {
+        let auth_manager = self.state.provider.auth_manager();
+        let (auth, auth_connection_changed) = match auth_manager.as_ref() {
+            Some(manager) => {
+                let cached_before_reload = auth_connection_key(manager.auth_cached().as_ref());
+                manager.reload();
+                let auth = self.state.provider.auth().await;
+                let auth_connection_changed =
+                    cached_before_reload != auth_connection_key(auth.as_ref());
+                (auth, auth_connection_changed)
+            }
+            None => (self.state.provider.auth().await, false),
+        };
+        let api_provider = self.state.provider.api_provider().await?;
+        let api_auth = match (agent_task, auth_manager.as_ref(), auth.as_ref()) {
+            (Some(agent_task), Some(auth_manager), Some(auth)) => {
+                if let Some(authorization_header_value) = auth_manager
+                    .chatgpt_agent_task_authorization_header_for_auth(
+                        auth,
+                        agent_task.authorization_target(),
+                    )
+                    .map_err(|err| {
+                        CodexErr::Stream(
+                            format!("failed to build agent assertion authorization: {err}"),
+                            None,
+                        )
+                    })?
+                {
+                    debug!(
+                        agent_runtime_id = %agent_task.agent_runtime_id,
+                        task_id = %agent_task.task_id,
+                        "using agent assertion authorization for downstream request"
+                    );
+                    let mut auth_provider = AuthorizationHeaderAuthProvider::new(
+                        Some(authorization_header_value),
+                        /*account_id*/ None,
+                    );
+                    if auth.is_fedramp_account() {
+                        auth_provider = auth_provider.with_fedramp_routing_header();
+                    }
+                    Arc::new(auth_provider)
+                } else {
+                    self.state.provider.api_auth().await?
+                }
+            }
+            _ => self.state.provider.api_auth().await?,
+        };
+        Ok(CurrentClientSetup {
+            auth,
+            api_provider,
+            api_auth,
+            auth_connection_changed,
+        })
+    }
+`,
+      },
+    ],
   },
   {
     id: "preconnect-websocket-reset-on-auth-change",
-    search: `        if !self.client.responses_websocket_enabled() {
+    variants: [
+      {
+        search: `        if !self.client.responses_websocket_enabled() {
             return Ok(());
         }
         if self.websocket_session.connection.is_some() {
@@ -110,7 +245,7 @@ fn auth_connection_key(auth: Option<&CodexAuth>) -> Option<AuthConnectionKey> {
             ))
         })?;
 `,
-    replacement: `        if !self.client.responses_websocket_enabled() {
+        replacement: `        if !self.client.responses_websocket_enabled() {
             return Ok(());
         }
         let client_setup = self.client.current_client_setup().await.map_err(|err| {
@@ -124,6 +259,45 @@ fn auth_connection_key(auth: Option<&CodexAuth>) -> Option<AuthConnectionKey> {
             return Ok(());
         }
 `,
+      },
+      {
+        search: `        if !self.client.responses_websocket_enabled() {
+            return Ok(());
+        }
+        if self.websocket_session.connection.is_some() {
+            return Ok(());
+        }
+
+        let client_setup = self
+            .client
+            .current_client_setup(self.agent_task.as_ref())
+            .await
+            .map_err(|err| {
+                ApiError::Stream(format!(
+                    "failed to build websocket prewarm client setup: {err}"
+                ))
+            })?;
+`,
+        replacement: `        if !self.client.responses_websocket_enabled() {
+            return Ok(());
+        }
+        let client_setup = self
+            .client
+            .current_client_setup(self.agent_task.as_ref())
+            .await
+            .map_err(|err| {
+                ApiError::Stream(format!(
+                    "failed to build websocket prewarm client setup: {err}"
+                ))
+            })?;
+        if client_setup.auth_connection_changed {
+            self.reset_websocket_session();
+        } else if self.websocket_session.connection.is_some() {
+            return Ok(());
+        }
+`,
+      },
+    ],
   },
   {
     id: "websocket-params-destructure",
@@ -173,7 +347,9 @@ fn auth_connection_key(auth: Option<&CodexAuth>) -> Option<AuthConnectionKey> {
   },
   {
     id: "websocket-connect-params-field",
-    search: `struct WebsocketConnectParams<'a> {
+    variants: [
+      {
+        search: `struct WebsocketConnectParams<'a> {
     session_telemetry: &'a SessionTelemetry,
     api_provider: codex_api::Provider,
     api_auth: CoreAuthProvider,
@@ -183,7 +359,7 @@ fn auth_connection_key(auth: Option<&CodexAuth>) -> Option<AuthConnectionKey> {
     request_route_telemetry: RequestRouteTelemetry,
 }
 `,
-    replacement: `struct WebsocketConnectParams<'a> {
+        replacement: `struct WebsocketConnectParams<'a> {
     session_telemetry: &'a SessionTelemetry,
     api_provider: codex_api::Provider,
     api_auth: CoreAuthProvider,
@@ -194,6 +370,31 @@ fn auth_connection_key(auth: Option<&CodexAuth>) -> Option<AuthConnectionKey> {
     request_route_telemetry: RequestRouteTelemetry,
 }
 `,
+      },
+      {
+        search: `struct WebsocketConnectParams<'a> {
+    session_telemetry: &'a SessionTelemetry,
+    api_provider: codex_api::Provider,
+    api_auth: SharedAuthProvider,
+    turn_metadata_header: Option<&'a str>,
+    options: &'a ApiResponsesOptions,
+    auth_context: AuthRequestTelemetryContext,
+    request_route_telemetry: RequestRouteTelemetry,
+}
+`,
+        replacement: `struct WebsocketConnectParams<'a> {
+    session_telemetry: &'a SessionTelemetry,
+    api_provider: codex_api::Provider,
+    api_auth: SharedAuthProvider,
+    turn_metadata_header: Option<&'a str>,
+    options: &'a ApiResponsesOptions,
+    auth_context: AuthRequestTelemetryContext,
+    auth_connection_changed: bool,
+    request_route_telemetry: RequestRouteTelemetry,
+}
+`,
+      },
+    ],
   },
 ];
 
@@ -307,9 +508,9 @@ export async function applyMaintainedPatch({
     mode,
   });
 
-  const fallbackPatchPath = path.join(projectRoot, TEST_FALLBACK_PATCH);
-  const fallbackPatch = await applyFallbackPatch({
-    patchPath: fallbackPatchPath,
+  const fallbackPatchPaths = TEST_FALLBACK_PATCHES.map((patchPath) => path.join(projectRoot, patchPath));
+  const fallbackPatch = await applyFallbackPatches({
+    patchPaths: fallbackPatchPaths,
     upstreamRoot,
     mode,
   });
@@ -398,22 +599,27 @@ function applyRewritePlan(initialText, rewrites) {
 }
 
 function replaceUnique(text, rewrite) {
-  if (text.includes(rewrite.replacement) && !text.includes(rewrite.search)) {
+  const variants = rewrite.variants ?? [rewrite];
+  const searchMatches = variants.reduce((sum, variant) => sum + countOccurrences(text, variant.search), 0);
+  const replacementPresent = variants.some((variant) => text.includes(variant.replacement));
+
+  if (replacementPresent && searchMatches === 0) {
     return { text, step: { id: rewrite.id, status: "already-applied" } };
   }
 
-  const matches = countOccurrences(text, rewrite.search);
-  if (matches !== 1) {
-    if (rewrite.optional && matches === 0) {
+  const matchedVariants = variants.filter((variant) => countOccurrences(text, variant.search) > 0);
+  if (matchedVariants.length !== 1 || searchMatches !== 1) {
+    if (rewrite.optional && searchMatches === 0) {
       return { text, step: { id: rewrite.id, status: "skipped" } };
     }
     throw new Error(
-      `rewrite ${rewrite.id} expected exactly one match, found ${matches}`,
+      `rewrite ${rewrite.id} expected exactly one match, found ${searchMatches}`,
     );
   }
 
+  const [selectedVariant] = matchedVariants;
   return {
-    text: text.replace(rewrite.search, rewrite.replacement),
+    text: text.replace(selectedVariant.search, selectedVariant.replacement),
     step: { id: rewrite.id, status: "applied" },
   };
 }
@@ -439,6 +645,20 @@ function insertAfterUnique(text, rewrite) {
   };
 }
 
+async function applyFallbackPatches({ patchPaths, upstreamRoot, mode }) {
+  const failures = [];
+
+  for (const patchPath of patchPaths) {
+    try {
+      return await applyFallbackPatch({ patchPath, upstreamRoot, mode });
+    } catch (error) {
+      failures.push(`${patchPath}: ${error.message}`);
+    }
+  }
+
+  throw new Error(`fallback patch drifted: ${failures.join("\n")}`);
+}
+
 async function applyFallbackPatch({ patchPath, upstreamRoot, mode }) {
   const applyCheck = await runGitApply(["--check", patchPath], upstreamRoot);
   if (applyCheck.ok) {
@@ -457,7 +677,7 @@ async function applyFallbackPatch({ patchPath, upstreamRoot, mode }) {
   }
 
   throw new Error(
-    `fallback patch drifted: ${applyCheck.stderr || applyCheck.stdout || reverseCheck.stderr || reverseCheck.stdout}`.trim(),
+    `${applyCheck.stderr || applyCheck.stdout || reverseCheck.stderr || reverseCheck.stdout}`.trim(),
   );
 }
 

--- a/test/maintained-patch.test.js
+++ b/test/maintained-patch.test.js
@@ -124,6 +124,159 @@ test("applyClientRuntimeRewrites patches the runtime hot-reload changes and is i
   assert.equal(second.steps.every((step) => step.status === "already-applied"), true);
 });
 
+const CLEAN_CLIENT_0122_SNIPPET = `struct CurrentClientSetup {
+    auth: Option<CodexAuth>,
+    api_provider: ApiProvider,
+    api_auth: SharedAuthProvider,
+}
+
+#[derive(Clone, Copy)]
+struct RequestRouteTelemetry {
+    endpoint: &'static str,
+}
+
+impl RequestRouteTelemetry {
+    fn for_endpoint(endpoint: &'static str) -> Self {
+        Self { endpoint }
+    }
+}
+
+    async fn current_client_setup(
+        &self,
+        agent_task: Option<&RegisteredAgentTask>,
+    ) -> Result<CurrentClientSetup> {
+        let auth = self.state.provider.auth().await;
+        let api_provider = self.state.provider.api_provider().await?;
+        let auth_manager = self.state.provider.auth_manager();
+        let api_auth = match (agent_task, auth_manager.as_ref(), auth.as_ref()) {
+            (Some(agent_task), Some(auth_manager), Some(auth)) => {
+                if let Some(authorization_header_value) = auth_manager
+                    .chatgpt_agent_task_authorization_header_for_auth(
+                        auth,
+                        agent_task.authorization_target(),
+                    )
+                    .map_err(|err| {
+                        CodexErr::Stream(
+                            format!("failed to build agent assertion authorization: {err}"),
+                            None,
+                        )
+                    })?
+                {
+                    debug!(
+                        agent_runtime_id = %agent_task.agent_runtime_id,
+                        task_id = %agent_task.task_id,
+                        "using agent assertion authorization for downstream request"
+                    );
+                    let mut auth_provider = AuthorizationHeaderAuthProvider::new(
+                        Some(authorization_header_value),
+                        /*account_id*/ None,
+                    );
+                    if auth.is_fedramp_account() {
+                        auth_provider = auth_provider.with_fedramp_routing_header();
+                    }
+                    Arc::new(auth_provider)
+                } else {
+                    self.state.provider.api_auth().await?
+                }
+            }
+            _ => self.state.provider.api_auth().await?,
+        };
+        Ok(CurrentClientSetup {
+            auth,
+            api_provider,
+            api_auth,
+        })
+    }
+
+    pub async fn preconnect_websocket(
+        &mut self,
+        session_telemetry: &SessionTelemetry,
+        _model_info: &ModelInfo,
+    ) -> std::result::Result<(), ApiError> {
+        if !self.client.responses_websocket_enabled() {
+            return Ok(());
+        }
+        if self.websocket_session.connection.is_some() {
+            return Ok(());
+        }
+
+        let client_setup = self
+            .client
+            .current_client_setup(self.agent_task.as_ref())
+            .await
+            .map_err(|err| {
+                ApiError::Stream(format!(
+                    "failed to build websocket prewarm client setup: {err}"
+                ))
+            })?;
+        let auth_context = AuthRequestTelemetryContext::new(
+            client_setup.auth.as_ref().map(CodexAuth::auth_mode),
+            client_setup.api_auth.as_ref(),
+            PendingUnauthorizedRetry::default(),
+        );
+        let connection = self
+            .client
+            .connect_websocket(
+                session_telemetry,
+                client_setup.api_provider,
+                client_setup.api_auth,
+                Some(Arc::clone(&self.turn_state)),
+                /*turn_metadata_header*/ None,
+                auth_context,
+                RequestRouteTelemetry::for_endpoint(RESPONSES_ENDPOINT),
+            )
+            .await?;
+        self.websocket_session.connection = Some(connection);
+        self.websocket_session
+            .set_connection_reused(/*connection_reused*/ false);
+        Ok(())
+    }
+
+            turn_metadata_header,
+            options,
+            auth_context,
+            request_route_telemetry,
+        } = params;
+        let needs_new = match self.websocket_session.connection.as_ref() {
+            Some(conn) => conn.is_closed().await,
+            None => true,
+        };
+
+                    turn_metadata_header,
+                    options: &options,
+                    auth_context: request_auth_context,
+                    request_route_telemetry: RequestRouteTelemetry::for_endpoint(
+                        RESPONSES_ENDPOINT,
+                    ),
+
+struct WebsocketConnectParams<'a> {
+    session_telemetry: &'a SessionTelemetry,
+    api_provider: codex_api::Provider,
+    api_auth: SharedAuthProvider,
+    turn_metadata_header: Option<&'a str>,
+    options: &'a ApiResponsesOptions,
+    auth_context: AuthRequestTelemetryContext,
+    request_route_telemetry: RequestRouteTelemetry,
+}
+`;
+
+test("applyClientRuntimeRewrites patches the upstream 0.122 runtime layout and is idempotent", () => {
+  const first = applyClientRuntimeRewrites(CLEAN_CLIENT_0122_SNIPPET);
+
+  assert.equal(first.steps.every((step) => step.status === "applied"), true);
+  assert.match(first.text, /auth_connection_changed: bool,/);
+  assert.match(first.text, /let \(auth, auth_connection_changed\) = match auth_manager\.as_ref\(\)/);
+  assert.match(first.text, /manager\.reload\(\);/);
+  assert.match(first.text, /None => \(self\.state\.provider\.auth\(\)\.await, false\),/);
+  assert.match(first.text, /if client_setup\.auth_connection_changed \{/);
+  assert.match(first.text, /auth_connection_changed: client_setup\.auth_connection_changed,/);
+
+  const second = applyClientRuntimeRewrites(first.text);
+
+  assert.equal(second.changed, false);
+  assert.equal(second.steps.every((step) => step.status === "already-applied"), true);
+});
+
 const CLEAN_TEST_SUITE_MOD_SNIPPET = `// Aggregates all former standalone integration tests as modules.
 use std::ffi::OsString;
 use std::path::Path;


### PR DESCRIPTION
## Summary
- support the 0.122.0 client runtime drift in the maintained patcher
- add a 0.122-specific fallback test patch for upstream test drift
- add regression coverage for the new 0.122 client layout

## Validation
- npm test
- npm run patch:check -- --upstream-root <rust-v0.122.0 source tree>

Closes #3