### PR TITLE
Harden compatibility sweep and Rust cache paths

### DIFF
--- a/.github/workflows/compatibility-sweep.yml
+++ b/.github/workflows/compatibility-sweep.yml
@@ -1,6 +1,20 @@
 name: compatibility-sweep
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/compatibility-sweep.yml"
+      - ".github/workflows/publish-hotpatch.yml"
+      - "package.json"
+      - "patches/**"
+      - "scripts/apply-maintained-patch.mjs"
+      - "scripts/resolve-version-matrix.mjs"
+      - "src/lib/maintained-patch.js"
+      - "src/lib/upstream-versions.js"
+      - "test/maintained-patch.test.js"
+      - "test/upstream-versions.test.js"
   workflow_dispatch:
     inputs:
       versions:
@@ -31,6 +45,7 @@ concurrency:
 jobs:
   resolve-matrix:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       matrix: ${{ steps.resolve.outputs.matrix }}
     steps:
@@ -59,14 +74,13 @@ jobs:
   sweep:
     needs: resolve-matrix
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.resolve-matrix.outputs.matrix) }}
     env:
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -80,11 +94,12 @@ jobs:
           ref: ${{ matrix.codex_ref }}
           path: upstream
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: sweep-${{ matrix.platform }}-${{ matrix.codex_version }}
           cache-on-failure: "true"
+          workspaces: |
+            upstream/codex-rs -> upstream/codex-rs/target
       - name: Install Linux build dependencies
         if: matrix.os == 'ubuntu-latest'
         shell: bash
@@ -119,4 +134,3 @@ jobs:
             upstream/codex-rs/core/src/client_tests.rs
             upstream/codex-rs/core/tests/common/responses.rs
             upstream/codex-rs/core/tests/suite/client_websockets.rs
-

--- a/.github/workflows/publish-hotpatch.yml
+++ b/.github/workflows/publish-hotpatch.yml
@@ -75,6 +75,7 @@ concurrency:
 jobs:
   detect-upstream:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       codex_version: ${{ steps.detect.outputs.codex_version }}
       codex_ref: ${{ steps.detect.outputs.codex_ref }}
@@ -121,6 +122,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.detect-upstream.outputs.target_matrix) }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -151,11 +153,10 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.detect-upstream.outputs.target_matrix) }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 150
     env:
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -176,13 +177,13 @@ jobs:
           path: upstream
       - uses: dtolnay/rust-toolchain@stable
         if: needs.detect-upstream.outputs.build_mode == 'rebuild'
-      - uses: mozilla-actions/sccache-action@v0.0.9
-        if: needs.detect-upstream.outputs.build_mode == 'rebuild'
       - uses: Swatinem/rust-cache@v2
         if: needs.detect-upstream.outputs.build_mode == 'rebuild'
         with:
           shared-key: publish-${{ matrix.platform }}-${{ needs.detect-upstream.outputs.codex_version }}
           cache-on-failure: "true"
+          workspaces: |
+            upstream/codex-rs -> upstream/codex-rs/target
       - name: Install Linux build dependencies
         if: needs.detect-upstream.outputs.build_mode == 'rebuild' && matrix.os == 'ubuntu-latest'
         shell: bash
@@ -244,6 +245,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.detect-upstream.outputs.target_matrix) }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -282,6 +284,7 @@ jobs:
   publish:
     needs: [detect-upstream, build-manifests]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
Summary
- refresh compatibility-sweep on relevant main pushes so the badge does not stay stale after maintenance fixes
- add job timeouts for the sweep and publish lanes
- configure Swatinem/rust-cache against upstream/codex-rs explicitly so Windows and Linux cache the actual Rust workspace

Validation
- npm test
- compatibility-sweep workflow on fix/ci-resilience with versions=0.122.0 and target_set=full (run 24792774368)
