### PR TITLE
Support upstream Codex 0.128.0 and 0.129.0

### DIFF
--- a/patches/codex-hot-reload-tests-0.128.patch
+++ b/patches/codex-hot-reload-tests-0.128.patch
@@ -1,0 +1,689 @@
+diff --git a/codex-rs/core/src/client_tests.rs b/codex-rs/core/src/client_tests.rs
+index e56500b..dd5b073 100644
+--- a/codex-rs/core/src/client_tests.rs
++++ b/codex-rs/core/src/client_tests.rs
+@@ -10,6 +10,8 @@ use super::X_OPENAI_SUBAGENT_HEADER;
+ use codex_api::ApiError;
+ use codex_api::ResponseEvent;
+ use codex_app_server_protocol::AuthMode;
++use codex_config::types::AuthCredentialsStoreMode;
++use codex_login::CodexAuth;
+ use codex_model_provider::BearerAuthProvider;
+ use codex_model_provider_info::WireApi;
+ use codex_model_provider_info::create_oss_provider_with_base_url;
+@@ -32,6 +34,7 @@ use futures::StreamExt;
+ use pretty_assertions::assert_eq;
+ use serde_json::json;
+ use std::collections::VecDeque;
++use std::path::Path;
+ use std::pin::Pin;
+ use std::sync::Arc;
+ use std::task::Context;
+@@ -55,6 +58,45 @@ fn test_model_client(session_source: SessionSource) -> ModelClient {
+     )
+ }
+ 
++#[expect(clippy::unwrap_used)]
++fn write_chatgpt_auth_json(codex_home: &Path, access_token: &str, account_id: &str) {
++    use base64::Engine as _;
++
++    let header = json!({ "alg": "none", "typ": "JWT" });
++    let payload = json!({
++        "email": "user@example.com",
++        "https://api.openai.com/auth": {
++            "chatgpt_plan_type": "plus",
++            "chatgpt_account_id": account_id
++        }
++    });
++    let b64 = |bytes: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
++    let fake_jwt = format!(
++        "{}.{}.{}",
++        b64(&serde_json::to_vec(&header).unwrap()),
++        b64(&serde_json::to_vec(&payload).unwrap()),
++        b64(b"sig")
++    );
++
++    let auth_json = json!({
++        "auth_mode": "chatgpt",
++        "OPENAI_API_KEY": null,
++        "tokens": {
++            "id_token": fake_jwt,
++            "access_token": access_token,
++            "refresh_token": "refresh-test",
++            "account_id": account_id
++        },
++        "last_refresh": chrono::Utc::now(),
++    });
++
++    std::fs::write(
++        codex_home.join("auth.json"),
++        serde_json::to_string_pretty(&auth_json).unwrap(),
++    )
++    .unwrap();
++}
++
+ fn test_model_info() -> ModelInfo {
+     serde_json::from_value(json!({
+         "slug": "gpt-test",
+@@ -383,3 +425,62 @@ fn auth_request_telemetry_context_tracks_attached_auth_and_retry_phase() {
+     assert_eq!(auth_context.recovery_mode, Some("managed"));
+     assert_eq!(auth_context.recovery_phase, Some("refresh_token"));
+ }
++
++#[tokio::test]
++async fn current_client_setup_reloads_auth_from_disk_between_turns() {
++    let codex_home = TempDir::new().expect("tempdir");
++    write_chatgpt_auth_json(codex_home.path(), "token-one", "acc-one");
++
++    let provider = create_oss_provider_with_base_url("https://example.com/v1", WireApi::Responses);
++    let auth = CodexAuth::from_auth_storage(
++        codex_home.path(),
++        AuthCredentialsStoreMode::File,
++        /*chatgpt_base_url*/ None,
++    )
++    .await
++    .expect("load auth")
++    .expect("auth exists");
++    let auth_manager =
++        crate::test_support::auth_manager_from_auth_with_home(auth, codex_home.path().to_path_buf());
++    let client = ModelClient::new(
++        Some(auth_manager),
++        ThreadId::new(),
++        /*installation_id*/ "11111111-1111-4111-8111-111111111111".to_string(),
++        provider,
++        SessionSource::Cli,
++        /*model_verbosity*/ None,
++        /*enable_request_compression*/ false,
++        /*include_timing_metrics*/ false,
++        /*beta_features_header*/ None,
++    );
++
++    let first = client
++        .current_client_setup()
++        .await
++        .expect("first client setup");
++    assert_eq!(
++        first
++            .auth
++            .as_ref()
++            .and_then(|auth| auth.get_token().ok())
++            .as_deref(),
++        Some("token-one")
++    );
++    assert!(!first.auth_connection_changed);
++
++    write_chatgpt_auth_json(codex_home.path(), "token-two", "acc-two");
++
++    let second = client
++        .current_client_setup()
++        .await
++        .expect("second client setup");
++    assert_eq!(
++        second
++            .auth
++            .as_ref()
++            .and_then(|auth| auth.get_token().ok())
++            .as_deref(),
++        Some("token-two")
++    );
++    assert!(second.auth_connection_changed);
++}
+diff --git a/codex-rs/core/tests/common/responses.rs b/codex-rs/core/tests/common/responses.rs
+index 93472e7..5dcbf51 100644
+--- a/codex-rs/core/tests/common/responses.rs
++++ b/codex-rs/core/tests/common/responses.rs
+@@ -3,6 +3,8 @@
+ use std::collections::VecDeque;
+ use std::sync::Arc;
+ use std::sync::Mutex;
++use std::sync::atomic::AtomicBool;
++use std::sync::atomic::Ordering;
+ use std::time::Duration;
+ 
+ use anyhow::Result;
+@@ -16,6 +18,8 @@ use serde_json::Value;
+ use tokio::net::TcpListener;
+ use tokio::sync::Notify;
+ use tokio::sync::oneshot;
++use tokio::sync::watch;
++use tokio::task::JoinSet;
+ use tokio_tungstenite::accept_hdr_async_with_config;
+ use tokio_tungstenite::tungstenite::Message;
+ use tokio_tungstenite::tungstenite::extensions::ExtensionsConfig;
+@@ -1278,16 +1282,23 @@ pub async fn start_websocket_server_with_headers(
+     let request_log = Arc::clone(&request_log_updated);
+     let connections = Arc::new(Mutex::new(VecDeque::from(connections)));
+     let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
++    let shutdown_state = Arc::new(AtomicBool::new(false));
++    let (shutdown_watch_tx, shutdown_watch_rx) = watch::channel(false);
+ 
+     let task = tokio::spawn(async move {
++        let mut connection_tasks = JoinSet::new();
+         loop {
+             let accept_res = tokio::select! {
+-                _ = &mut shutdown_rx => return,
++                _ = &mut shutdown_rx => {
++                    shutdown_state.store(true, Ordering::SeqCst);
++                    let _ = shutdown_watch_tx.send(true);
++                    break;
++                },
+                 accept_res = listener.accept() => accept_res,
+             };
+             let (stream, _) = match accept_res {
+                 Ok(value) => value,
+-                Err(_) => return,
++                Err(_) => break,
+             };
+             let connection = {
+                 let mut pending = connections.lock().unwrap();
+@@ -1298,132 +1309,152 @@ pub async fn start_websocket_server_with_headers(
+                 continue;
+             };
+ 
+-            if let Some(delay) = connection.accept_delay {
+-                tokio::time::sleep(delay).await;
+-            }
+-
+             let response_headers = connection.response_headers.clone();
+             let handshake_log = Arc::clone(&handshakes);
+-            let callback = move |req: &Request, mut response: Response| {
+-                let headers = req
+-                    .headers()
+-                    .iter()
+-                    .filter_map(|(name, value)| {
+-                        value
+-                            .to_str()
+-                            .ok()
+-                            .map(|value| (name.as_str().to_string(), value.to_string()))
+-                    })
+-                    .collect();
+-                handshake_log.lock().unwrap().push(WebSocketHandshake {
+-                    uri: req.uri().to_string(),
+-                    headers,
+-                });
+-
+-                let headers_mut = response.headers_mut();
+-                for (name, value) in &response_headers {
+-                    if let (Ok(name), Ok(value)) = (
+-                        HeaderName::from_bytes(name.as_bytes()),
+-                        HeaderValue::from_str(value),
+-                    ) {
+-                        headers_mut.insert(name, value);
+-                    }
++            let requests = Arc::clone(&requests);
++            let request_log = Arc::clone(&request_log);
++            let start = start;
++            let shutdown_state = Arc::clone(&shutdown_state);
++            let mut shutdown_watch = shutdown_watch_rx.clone();
++
++            connection_tasks.spawn(async move {
++                if let Some(delay) = connection.accept_delay {
++                    tokio::time::sleep(delay).await;
+                 }
+ 
+-                Ok(response)
+-            };
++                let callback = move |req: &Request, mut response: Response| {
++                    let headers = req
++                        .headers()
++                        .iter()
++                        .filter_map(|(name, value)| {
++                            value
++                                .to_str()
++                                .ok()
++                                .map(|value| (name.as_str().to_string(), value.to_string()))
++                        })
++                        .collect();
++                    handshake_log.lock().unwrap().push(WebSocketHandshake {
++                        uri: req.uri().to_string(),
++                        headers,
++                    });
++
++                    let headers_mut = response.headers_mut();
++                    for (name, value) in &response_headers {
++                        if let (Ok(name), Ok(value)) = (
++                            HeaderName::from_bytes(name.as_bytes()),
++                            HeaderValue::from_str(value),
++                        ) {
++                            headers_mut.insert(name, value);
++                        }
++                    }
+ 
+-            let mut ws_stream = match accept_hdr_async_with_config(
+-                stream,
+-                callback,
+-                Some(websocket_accept_config()),
+-            )
+-            .await
+-            {
+-                Ok(ws) => ws,
+-                Err(_) => continue,
+-            };
++                    Ok(response)
++                };
+ 
+-            let connection_index = {
+-                let mut log = requests.lock().unwrap();
+-                log.push(Vec::new());
+-                log.len() - 1
+-            };
+-            let close_after_requests = connection.close_after_requests;
+-            for request_events in connection.requests {
+-                let Some(Ok(message)) = ws_stream.next().await else {
+-                    break;
++                let mut ws_stream = match accept_hdr_async_with_config(
++                    stream,
++                    callback,
++                    Some(websocket_accept_config()),
++                )
++                .await
++                {
++                    Ok(ws) => ws,
++                    Err(_) => return,
+                 };
+-                if let Some(body) = parse_ws_request_body(message) {
+-                    let mut log = requests.lock().unwrap();
+-                    if let Some(connection_log) = log.get_mut(connection_index) {
+-                        connection_log.push(WebSocketRequest { body });
+-                        let request_index = connection_log.len() - 1;
+-                        let request = &connection_log[request_index];
+-                        let request_body = request.body_json();
+-                        eprintln!(
+-                            "[ws test server +{}ms] connection={} received request={} type={:?} role={:?} text={:?} data={:?}",
+-                            start.elapsed().as_millis(),
+-                            connection_index,
+-                            request_index,
+-                            request_body.get("type").and_then(Value::as_str),
+-                            request_body
+-                                .get("item")
+-                                .and_then(|item| item.get("role"))
+-                                .and_then(Value::as_str),
+-                            request_body
+-                                .get("item")
+-                                .and_then(|item| item.get("content"))
+-                                .and_then(Value::as_array)
+-                                .and_then(|content| content.first())
+-                                .and_then(|content| content.get("text"))
+-                                .and_then(Value::as_str),
+-                            request_body
+-                                .get("item")
+-                                .and_then(|item| item.get("content"))
+-                                .and_then(Value::as_array)
+-                                .and_then(|content| content.first())
+-                                .and_then(|content| content.get("data"))
+-                                .and_then(Value::as_str),
+-                        );
+-                    }
+-                    request_log.notify_waiters();
+-                }
+ 
+-                eprintln!(
+-                    "[ws test server +{}ms] connection={} sending batch_size={} event_types={:?} audio_data={:?}",
+-                    start.elapsed().as_millis(),
+-                    connection_index,
+-                    request_events.len(),
+-                    request_events
+-                        .iter()
+-                        .map(|event| event.get("type").and_then(Value::as_str))
+-                        .collect::<Vec<_>>(),
+-                    request_events
+-                        .iter()
+-                        .find_map(|event| event.get("delta").and_then(Value::as_str)),
+-                );
+-                for event in &request_events {
+-                    let Ok(payload) = serde_json::to_string(event) else {
+-                        continue;
++                let connection_index = {
++                    let mut log = requests.lock().unwrap();
++                    log.push(Vec::new());
++                    log.len() - 1
++                };
++                let close_after_requests = connection.close_after_requests;
++                for request_events in connection.requests {
++                    let message = if close_after_requests || *shutdown_watch.borrow() {
++                        ws_stream.next().await
++                    } else {
++                        tokio::select! {
++                            message = ws_stream.next() => message,
++                            changed = shutdown_watch.changed() => {
++                                let _ = changed;
++                                None
++                            }
++                        }
+                     };
+-                    if ws_stream.send(Message::Text(payload.into())).await.is_err() {
++                    let Some(Ok(message)) = message else {
+                         break;
++                    };
++                    if let Some(body) = parse_ws_request_body(message) {
++                        let mut log = requests.lock().unwrap();
++                        if let Some(connection_log) = log.get_mut(connection_index) {
++                            connection_log.push(WebSocketRequest { body });
++                            let request_index = connection_log.len() - 1;
++                            let request = &connection_log[request_index];
++                            let request_body = request.body_json();
++                            eprintln!(
++                                "[ws test server +{}ms] connection={} received request={} type={:?} role={:?} text={:?} data={:?}",
++                                start.elapsed().as_millis(),
++                                connection_index,
++                                request_index,
++                                request_body.get("type").and_then(Value::as_str),
++                                request_body
++                                    .get("item")
++                                    .and_then(|item| item.get("role"))
++                                    .and_then(Value::as_str),
++                                request_body
++                                    .get("item")
++                                    .and_then(|item| item.get("content"))
++                                    .and_then(Value::as_array)
++                                    .and_then(|content| content.first())
++                                    .and_then(|content| content.get("text"))
++                                    .and_then(Value::as_str),
++                                request_body
++                                    .get("item")
++                                    .and_then(|item| item.get("content"))
++                                    .and_then(Value::as_array)
++                                    .and_then(|content| content.first())
++                                    .and_then(|content| content.get("data"))
++                                    .and_then(Value::as_str),
++                            );
++                        }
++                        request_log.notify_waiters();
+                     }
+-                }
+-            }
+ 
+-            if close_after_requests {
+-                let _ = ws_stream.close(None).await;
+-            } else {
+-                let _ = shutdown_rx.await;
+-                return;
+-            }
++                    eprintln!(
++                        "[ws test server +{}ms] connection={} sending batch_size={} event_types={:?} audio_data={:?}",
++                        start.elapsed().as_millis(),
++                        connection_index,
++                        request_events.len(),
++                        request_events
++                            .iter()
++                            .map(|event| event.get("type").and_then(Value::as_str))
++                            .collect::<Vec<_>>(),
++                        request_events
++                            .iter()
++                            .find_map(|event| event.get("delta").and_then(Value::as_str)),
++                    );
++                    for event in &request_events {
++                        let Ok(payload) = serde_json::to_string(event) else {
++                            continue;
++                        };
++                        if ws_stream.send(Message::Text(payload.into())).await.is_err() {
++                            break;
++                        }
++                    }
++                }
+ 
+-            if connections.lock().unwrap().is_empty() {
+-                return;
+-            }
++                if close_after_requests {
++                    let _ = ws_stream.close(None).await;
++                } else if !shutdown_state.load(Ordering::SeqCst) {
++                    while !*shutdown_watch.borrow() {
++                        if shutdown_watch.changed().await.is_err() {
++                            break;
++                        }
++                    }
++                }
++            });
+         }
++
++        while connection_tasks.join_next().await.is_some() {}
+     });
+ 
+     WebSocketTestServer {
+diff --git a/codex-rs/core/tests/suite/client_websockets.rs b/codex-rs/core/tests/suite/client_websockets.rs
+index cdbb65a..10fcf55 100755
+--- a/codex-rs/core/tests/suite/client_websockets.rs
++++ b/codex-rs/core/tests/suite/client_websockets.rs
+@@ -1,6 +1,7 @@
+ #![allow(clippy::expect_used, clippy::unwrap_used)]
+ use codex_api::WS_REQUEST_HEADER_TRACEPARENT_CLIENT_METADATA_KEY;
+ use codex_api::WS_REQUEST_HEADER_TRACESTATE_CLIENT_METADATA_KEY;
++use codex_config::types::AuthCredentialsStoreMode;
+ use codex_core::ModelClient;
+ use codex_core::ModelClientSession;
+ use codex_core::Prompt;
+@@ -45,6 +46,8 @@ use futures::StreamExt;
+ use opentelemetry_sdk::metrics::InMemoryMetricExporter;
+ use pretty_assertions::assert_eq;
+ use serde_json::json;
++use std::path::Path;
++use std::path::PathBuf;
+ use std::sync::Arc;
+ use std::time::Duration;
+ use tempfile::TempDir;
+@@ -86,6 +89,7 @@ fn assert_request_trace_matches(body: &serde_json::Value, expected_trace: &W3cTr
+ 
+ struct WebsocketTestHarness {
+     _codex_home: TempDir,
++    codex_home_path: PathBuf,
+     client: ModelClient,
+     conversation_id: ThreadId,
+     model_info: ModelInfo,
+@@ -94,6 +98,46 @@ struct WebsocketTestHarness {
+     session_telemetry: SessionTelemetry,
+ }
+ 
++#[expect(clippy::unwrap_used)]
++fn write_chatgpt_auth_json(codex_home: &Path, access_token: &str, account_id: &str) {
++    use base64::Engine as _;
++
++    let header = json!({ "alg": "none", "typ": "JWT" });
++    let payload = json!({
++        "email": "user@example.com",
++        "https://api.openai.com/auth": {
++            "chatgpt_plan_type": "plus",
++            "chatgpt_account_id": account_id,
++        }
++    });
++
++    let b64 = |bytes: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
++    let fake_jwt = format!(
++        "{}.{}.{}",
++        b64(&serde_json::to_vec(&header).unwrap()),
++        b64(&serde_json::to_vec(&payload).unwrap()),
++        b64(b"sig")
++    );
++
++    let auth_json = json!({
++        "auth_mode": "chatgpt",
++        "OPENAI_API_KEY": null,
++        "tokens": {
++            "id_token": fake_jwt,
++            "access_token": access_token,
++            "refresh_token": "refresh-test",
++            "account_id": account_id,
++        },
++        "last_refresh": chrono::Utc::now(),
++    });
++
++    std::fs::write(
++        codex_home.join("auth.json"),
++        serde_json::to_string_pretty(&auth_json).unwrap(),
++    )
++    .unwrap();
++}
++
+ #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+ async fn responses_websocket_streams_request() {
+     skip_if_no_network!();
+@@ -382,6 +426,75 @@ async fn responses_websocket_reuses_connection_after_session_drop() {
+     server.shutdown().await;
+ }
+ 
++#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
++async fn responses_websocket_reconnects_when_auth_snapshot_changes_between_turns() {
++    skip_if_no_network!();
++
++    let server = start_websocket_server_with_headers(vec![
++        WebSocketConnectionConfig {
++            requests: vec![
++                vec![ev_response_created("resp-1"), ev_completed("resp-1")],
++                vec![
++                    ev_response_created("resp-reused"),
++                    ev_completed("resp-reused"),
++                ],
++            ],
++            response_headers: Vec::new(),
++            accept_delay: None,
++            close_after_requests: false,
++        },
++        WebSocketConnectionConfig {
++            requests: vec![vec![ev_response_created("resp-2"), ev_completed("resp-2")]],
++            response_headers: Vec::new(),
++            accept_delay: None,
++            close_after_requests: false,
++        },
++    ])
++    .await;
++
++    let harness = authenticated_websocket_harness(&server).await;
++    let prompt_one = prompt_with_input(vec![message_item("hello")]);
++    let prompt_two = prompt_with_input(vec![message_item("switched")]);
++
++    let mut first_turn = harness.client.new_session();
++    tokio::time::timeout(
++        Duration::from_secs(5),
++        stream_until_complete(&mut first_turn, &harness, &prompt_one),
++    )
++    .await
++    .expect("first authenticated websocket turn timed out");
++    assert!(
++        server.wait_for_handshakes(1, Duration::from_secs(1)).await,
++        "expected first websocket handshake",
++    );
++
++    write_chatgpt_auth_json(&harness.codex_home_path, "token-two", "acc-two");
++
++    let mut second_turn = harness.client.new_session();
++    tokio::time::timeout(
++        Duration::from_secs(5),
++        stream_until_complete(&mut second_turn, &harness, &prompt_two),
++    )
++    .await
++    .expect("second authenticated websocket turn timed out");
++    assert!(
++        server.wait_for_handshakes(2, Duration::from_secs(1)).await,
++        "expected websocket reconnect after auth snapshot change",
++    );
++
++    assert_eq!(server.handshakes().len(), 2);
++    assert_eq!(
++        server.handshakes()[0].header("authorization").as_deref(),
++        Some("Bearer token-one")
++    );
++    assert_eq!(
++        server.handshakes()[1].header("authorization").as_deref(),
++        Some("Bearer token-two")
++    );
++
++    server.shutdown().await;
++}
++
+ #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+ async fn responses_websocket_preconnect_is_reused_even_with_header_changes() {
+     skip_if_no_network!();
+@@ -1761,6 +1874,12 @@ fn websocket_provider(server: &WebSocketTestServer) -> ModelProviderInfo {
+     websocket_provider_with_connect_timeout(server, /*websocket_connect_timeout_ms*/ None)
+ }
+ 
++fn authenticated_websocket_provider(server: &WebSocketTestServer) -> ModelProviderInfo {
++    let mut provider = websocket_provider(server);
++    provider.requires_openai_auth = true;
++    provider
++}
++
+ fn websocket_provider_with_connect_timeout(
+     server: &WebSocketTestServer,
+     websocket_connect_timeout_ms: Option<u64>,
+@@ -1816,7 +1935,33 @@ async fn websocket_harness_with_provider_options(
+     provider: ModelProviderInfo,
+     runtime_metrics_enabled: bool,
+ ) -> WebsocketTestHarness {
++    websocket_harness_with_provider_options_and_home(
++        provider,
++        runtime_metrics_enabled,
++        TempDir::new().unwrap(),
++        /*use_auth_from_home*/ false,
++    )
++    .await
++}
++
++async fn authenticated_websocket_harness(server: &WebSocketTestServer) -> WebsocketTestHarness {
+     let codex_home = TempDir::new().unwrap();
++    write_chatgpt_auth_json(codex_home.path(), "token-one", "acc-one");
++    websocket_harness_with_provider_options_and_home(
++        authenticated_websocket_provider(server),
++        /*runtime_metrics_enabled*/ false,
++        codex_home,
++        /*use_auth_from_home*/ true,
++    )
++    .await
++}
++
++async fn websocket_harness_with_provider_options_and_home(
++    provider: ModelProviderInfo,
++    runtime_metrics_enabled: bool,
++    codex_home: TempDir,
++    use_auth_from_home: bool,
++) -> WebsocketTestHarness {
+     let mut config = load_default_config_for_test(&codex_home).await;
+     config.model = Some(MODEL.to_string());
+     if runtime_metrics_enabled {
+@@ -1828,8 +1973,25 @@ async fn websocket_harness_with_provider_options(
+     let config = Arc::new(config);
+     let model_info = codex_core::test_support::construct_model_info_offline(MODEL, &config);
+     let conversation_id = ThreadId::new();
+-    let auth_manager =
+-        codex_core::test_support::auth_manager_from_auth(CodexAuth::from_api_key("Test API Key"));
++    let auth_manager = if use_auth_from_home {
++        let auth = match CodexAuth::from_auth_storage(
++            codex_home.path(),
++            AuthCredentialsStoreMode::File,
++            /*chatgpt_base_url*/ None,
++        )
++        .await
++        {
++            Ok(Some(auth)) => auth,
++            Ok(None) => panic!("No CodexAuth found in codex_home"),
++            Err(err) => panic!("Failed to load auth from codex_home: {err}"),
++        };
++        codex_core::test_support::auth_manager_from_auth_with_home(
++            auth,
++            codex_home.path().to_path_buf(),
++        )
++    } else {
++        codex_core::test_support::auth_manager_from_auth(CodexAuth::from_api_key("Test API Key"))
++    };
+     let exporter = InMemoryMetricExporter::default();
+     let metrics = MetricsClient::new(
+         MetricsConfig::in_memory("test", "codex-core", env!("CARGO_PKG_VERSION"), exporter)
+@@ -1851,8 +2013,9 @@ async fn websocket_harness_with_provider_options(
+     .with_metrics(metrics);
+     let effort = None;
+     let summary = ReasoningSummary::Auto;
++    let codex_home_path = codex_home.path().to_path_buf();
+     let client = ModelClient::new(
+-        /*auth_manager*/ None,
++        /*auth_manager*/ use_auth_from_home.then_some(auth_manager.clone()),
+         conversation_id,
+         /*installation_id*/ TEST_INSTALLATION_ID.to_string(),
+         provider.clone(),
+@@ -1865,6 +2028,7 @@ async fn websocket_harness_with_provider_options(
+ 
+     WebsocketTestHarness {
+         _codex_home: codex_home,
++        codex_home_path,
+         client,
+         conversation_id,
+         model_info,

--- a/patches/codex-hot-reload-tests-0.129.patch
+++ b/patches/codex-hot-reload-tests-0.129.patch
@@ -1,0 +1,691 @@
+diff --git a/codex-rs/core/src/client_tests.rs b/codex-rs/core/src/client_tests.rs
+index 2ba65d7..e44a390 100644
+--- a/codex-rs/core/src/client_tests.rs
++++ b/codex-rs/core/src/client_tests.rs
+@@ -10,6 +10,8 @@ use super::X_OPENAI_SUBAGENT_HEADER;
+ use codex_api::ApiError;
+ use codex_api::ResponseEvent;
+ use codex_app_server_protocol::AuthMode;
++use codex_config::types::AuthCredentialsStoreMode;
++use codex_login::CodexAuth;
+ use codex_model_provider::BearerAuthProvider;
+ use codex_model_provider_info::WireApi;
+ use codex_model_provider_info::create_oss_provider_with_base_url;
+@@ -33,6 +35,7 @@ use pretty_assertions::assert_eq;
+ use serde_json::json;
+ use std::collections::BTreeMap;
+ use std::collections::VecDeque;
++use std::path::Path;
+ use std::pin::Pin;
+ use std::sync::Arc;
+ use std::sync::Mutex;
+@@ -67,6 +70,45 @@ fn test_model_client(session_source: SessionSource) -> ModelClient {
+     )
+ }
+ 
++#[expect(clippy::unwrap_used)]
++fn write_chatgpt_auth_json(codex_home: &Path, access_token: &str, account_id: &str) {
++    use base64::Engine as _;
++
++    let header = json!({ "alg": "none", "typ": "JWT" });
++    let payload = json!({
++        "email": "user@example.com",
++        "https://api.openai.com/auth": {
++            "chatgpt_plan_type": "plus",
++            "chatgpt_account_id": account_id
++        }
++    });
++    let b64 = |bytes: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
++    let fake_jwt = format!(
++        "{}.{}.{}",
++        b64(&serde_json::to_vec(&header).unwrap()),
++        b64(&serde_json::to_vec(&payload).unwrap()),
++        b64(b"sig")
++    );
++
++    let auth_json = json!({
++        "auth_mode": "chatgpt",
++        "OPENAI_API_KEY": null,
++        "tokens": {
++            "id_token": fake_jwt,
++            "access_token": access_token,
++            "refresh_token": "refresh-test",
++            "account_id": account_id
++        },
++        "last_refresh": chrono::Utc::now(),
++    });
++
++    std::fs::write(
++        codex_home.join("auth.json"),
++        serde_json::to_string_pretty(&auth_json).unwrap(),
++    )
++    .unwrap();
++}
++
+ fn test_model_info() -> ModelInfo {
+     serde_json::from_value(json!({
+         "slug": "gpt-test",
+@@ -466,3 +508,64 @@ fn auth_request_telemetry_context_tracks_attached_auth_and_retry_phase() {
+     assert_eq!(auth_context.recovery_mode, Some("managed"));
+     assert_eq!(auth_context.recovery_phase, Some("refresh_token"));
+ }
++
++#[tokio::test]
++async fn current_client_setup_reloads_auth_from_disk_between_turns() {
++    let codex_home = TempDir::new().expect("tempdir");
++    write_chatgpt_auth_json(codex_home.path(), "token-one", "acc-one");
++
++    let provider = create_oss_provider_with_base_url("https://example.com/v1", WireApi::Responses);
++    let auth = CodexAuth::from_auth_storage(
++        codex_home.path(),
++        AuthCredentialsStoreMode::File,
++        /*chatgpt_base_url*/ None,
++    )
++    .await
++    .expect("load auth")
++    .expect("auth exists");
++    let auth_manager =
++        crate::test_support::auth_manager_from_auth_with_home(auth, codex_home.path().to_path_buf());
++    let thread_id = ThreadId::new();
++    let client = ModelClient::new(
++        Some(auth_manager),
++        thread_id.into(),
++        thread_id,
++        /*installation_id*/ "11111111-1111-4111-8111-111111111111".to_string(),
++        provider,
++        SessionSource::Cli,
++        /*model_verbosity*/ None,
++        /*enable_request_compression*/ false,
++        /*include_timing_metrics*/ false,
++        /*beta_features_header*/ None,
++    );
++
++    let first = client
++        .current_client_setup()
++        .await
++        .expect("first client setup");
++    assert_eq!(
++        first
++            .auth
++            .as_ref()
++            .and_then(|auth| auth.get_token().ok())
++            .as_deref(),
++        Some("token-one")
++    );
++    assert!(!first.auth_connection_changed);
++
++    write_chatgpt_auth_json(codex_home.path(), "token-two", "acc-two");
++
++    let second = client
++        .current_client_setup()
++        .await
++        .expect("second client setup");
++    assert_eq!(
++        second
++            .auth
++            .as_ref()
++            .and_then(|auth| auth.get_token().ok())
++            .as_deref(),
++        Some("token-two")
++    );
++    assert!(second.auth_connection_changed);
++}
+diff --git a/codex-rs/core/tests/common/responses.rs b/codex-rs/core/tests/common/responses.rs
+index 93472e7..5dcbf51 100644
+--- a/codex-rs/core/tests/common/responses.rs
++++ b/codex-rs/core/tests/common/responses.rs
+@@ -3,6 +3,8 @@
+ use std::collections::VecDeque;
+ use std::sync::Arc;
+ use std::sync::Mutex;
++use std::sync::atomic::AtomicBool;
++use std::sync::atomic::Ordering;
+ use std::time::Duration;
+ 
+ use anyhow::Result;
+@@ -16,6 +18,8 @@ use serde_json::Value;
+ use tokio::net::TcpListener;
+ use tokio::sync::Notify;
+ use tokio::sync::oneshot;
++use tokio::sync::watch;
++use tokio::task::JoinSet;
+ use tokio_tungstenite::accept_hdr_async_with_config;
+ use tokio_tungstenite::tungstenite::Message;
+ use tokio_tungstenite::tungstenite::extensions::ExtensionsConfig;
+@@ -1278,16 +1282,23 @@ pub async fn start_websocket_server_with_headers(
+     let request_log = Arc::clone(&request_log_updated);
+     let connections = Arc::new(Mutex::new(VecDeque::from(connections)));
+     let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
++    let shutdown_state = Arc::new(AtomicBool::new(false));
++    let (shutdown_watch_tx, shutdown_watch_rx) = watch::channel(false);
+ 
+     let task = tokio::spawn(async move {
++        let mut connection_tasks = JoinSet::new();
+         loop {
+             let accept_res = tokio::select! {
+-                _ = &mut shutdown_rx => return,
++                _ = &mut shutdown_rx => {
++                    shutdown_state.store(true, Ordering::SeqCst);
++                    let _ = shutdown_watch_tx.send(true);
++                    break;
++                },
+                 accept_res = listener.accept() => accept_res,
+             };
+             let (stream, _) = match accept_res {
+                 Ok(value) => value,
+-                Err(_) => return,
++                Err(_) => break,
+             };
+             let connection = {
+                 let mut pending = connections.lock().unwrap();
+@@ -1298,132 +1309,152 @@ pub async fn start_websocket_server_with_headers(
+                 continue;
+             };
+ 
+-            if let Some(delay) = connection.accept_delay {
+-                tokio::time::sleep(delay).await;
+-            }
+-
+             let response_headers = connection.response_headers.clone();
+             let handshake_log = Arc::clone(&handshakes);
+-            let callback = move |req: &Request, mut response: Response| {
+-                let headers = req
+-                    .headers()
+-                    .iter()
+-                    .filter_map(|(name, value)| {
+-                        value
+-                            .to_str()
+-                            .ok()
+-                            .map(|value| (name.as_str().to_string(), value.to_string()))
+-                    })
+-                    .collect();
+-                handshake_log.lock().unwrap().push(WebSocketHandshake {
+-                    uri: req.uri().to_string(),
+-                    headers,
+-                });
+-
+-                let headers_mut = response.headers_mut();
+-                for (name, value) in &response_headers {
+-                    if let (Ok(name), Ok(value)) = (
+-                        HeaderName::from_bytes(name.as_bytes()),
+-                        HeaderValue::from_str(value),
+-                    ) {
+-                        headers_mut.insert(name, value);
+-                    }
++            let requests = Arc::clone(&requests);
++            let request_log = Arc::clone(&request_log);
++            let start = start;
++            let shutdown_state = Arc::clone(&shutdown_state);
++            let mut shutdown_watch = shutdown_watch_rx.clone();
++
++            connection_tasks.spawn(async move {
++                if let Some(delay) = connection.accept_delay {
++                    tokio::time::sleep(delay).await;
+                 }
+ 
+-                Ok(response)
+-            };
++                let callback = move |req: &Request, mut response: Response| {
++                    let headers = req
++                        .headers()
++                        .iter()
++                        .filter_map(|(name, value)| {
++                            value
++                                .to_str()
++                                .ok()
++                                .map(|value| (name.as_str().to_string(), value.to_string()))
++                        })
++                        .collect();
++                    handshake_log.lock().unwrap().push(WebSocketHandshake {
++                        uri: req.uri().to_string(),
++                        headers,
++                    });
++
++                    let headers_mut = response.headers_mut();
++                    for (name, value) in &response_headers {
++                        if let (Ok(name), Ok(value)) = (
++                            HeaderName::from_bytes(name.as_bytes()),
++                            HeaderValue::from_str(value),
++                        ) {
++                            headers_mut.insert(name, value);
++                        }
++                    }
+ 
+-            let mut ws_stream = match accept_hdr_async_with_config(
+-                stream,
+-                callback,
+-                Some(websocket_accept_config()),
+-            )
+-            .await
+-            {
+-                Ok(ws) => ws,
+-                Err(_) => continue,
+-            };
++                    Ok(response)
++                };
+ 
+-            let connection_index = {
+-                let mut log = requests.lock().unwrap();
+-                log.push(Vec::new());
+-                log.len() - 1
+-            };
+-            let close_after_requests = connection.close_after_requests;
+-            for request_events in connection.requests {
+-                let Some(Ok(message)) = ws_stream.next().await else {
+-                    break;
++                let mut ws_stream = match accept_hdr_async_with_config(
++                    stream,
++                    callback,
++                    Some(websocket_accept_config()),
++                )
++                .await
++                {
++                    Ok(ws) => ws,
++                    Err(_) => return,
+                 };
+-                if let Some(body) = parse_ws_request_body(message) {
+-                    let mut log = requests.lock().unwrap();
+-                    if let Some(connection_log) = log.get_mut(connection_index) {
+-                        connection_log.push(WebSocketRequest { body });
+-                        let request_index = connection_log.len() - 1;
+-                        let request = &connection_log[request_index];
+-                        let request_body = request.body_json();
+-                        eprintln!(
+-                            "[ws test server +{}ms] connection={} received request={} type={:?} role={:?} text={:?} data={:?}",
+-                            start.elapsed().as_millis(),
+-                            connection_index,
+-                            request_index,
+-                            request_body.get("type").and_then(Value::as_str),
+-                            request_body
+-                                .get("item")
+-                                .and_then(|item| item.get("role"))
+-                                .and_then(Value::as_str),
+-                            request_body
+-                                .get("item")
+-                                .and_then(|item| item.get("content"))
+-                                .and_then(Value::as_array)
+-                                .and_then(|content| content.first())
+-                                .and_then(|content| content.get("text"))
+-                                .and_then(Value::as_str),
+-                            request_body
+-                                .get("item")
+-                                .and_then(|item| item.get("content"))
+-                                .and_then(Value::as_array)
+-                                .and_then(|content| content.first())
+-                                .and_then(|content| content.get("data"))
+-                                .and_then(Value::as_str),
+-                        );
+-                    }
+-                    request_log.notify_waiters();
+-                }
+ 
+-                eprintln!(
+-                    "[ws test server +{}ms] connection={} sending batch_size={} event_types={:?} audio_data={:?}",
+-                    start.elapsed().as_millis(),
+-                    connection_index,
+-                    request_events.len(),
+-                    request_events
+-                        .iter()
+-                        .map(|event| event.get("type").and_then(Value::as_str))
+-                        .collect::<Vec<_>>(),
+-                    request_events
+-                        .iter()
+-                        .find_map(|event| event.get("delta").and_then(Value::as_str)),
+-                );
+-                for event in &request_events {
+-                    let Ok(payload) = serde_json::to_string(event) else {
+-                        continue;
++                let connection_index = {
++                    let mut log = requests.lock().unwrap();
++                    log.push(Vec::new());
++                    log.len() - 1
++                };
++                let close_after_requests = connection.close_after_requests;
++                for request_events in connection.requests {
++                    let message = if close_after_requests || *shutdown_watch.borrow() {
++                        ws_stream.next().await
++                    } else {
++                        tokio::select! {
++                            message = ws_stream.next() => message,
++                            changed = shutdown_watch.changed() => {
++                                let _ = changed;
++                                None
++                            }
++                        }
+                     };
+-                    if ws_stream.send(Message::Text(payload.into())).await.is_err() {
++                    let Some(Ok(message)) = message else {
+                         break;
++                    };
++                    if let Some(body) = parse_ws_request_body(message) {
++                        let mut log = requests.lock().unwrap();
++                        if let Some(connection_log) = log.get_mut(connection_index) {
++                            connection_log.push(WebSocketRequest { body });
++                            let request_index = connection_log.len() - 1;
++                            let request = &connection_log[request_index];
++                            let request_body = request.body_json();
++                            eprintln!(
++                                "[ws test server +{}ms] connection={} received request={} type={:?} role={:?} text={:?} data={:?}",
++                                start.elapsed().as_millis(),
++                                connection_index,
++                                request_index,
++                                request_body.get("type").and_then(Value::as_str),
++                                request_body
++                                    .get("item")
++                                    .and_then(|item| item.get("role"))
++                                    .and_then(Value::as_str),
++                                request_body
++                                    .get("item")
++                                    .and_then(|item| item.get("content"))
++                                    .and_then(Value::as_array)
++                                    .and_then(|content| content.first())
++                                    .and_then(|content| content.get("text"))
++                                    .and_then(Value::as_str),
++                                request_body
++                                    .get("item")
++                                    .and_then(|item| item.get("content"))
++                                    .and_then(Value::as_array)
++                                    .and_then(|content| content.first())
++                                    .and_then(|content| content.get("data"))
++                                    .and_then(Value::as_str),
++                            );
++                        }
++                        request_log.notify_waiters();
+                     }
+-                }
+-            }
+ 
+-            if close_after_requests {
+-                let _ = ws_stream.close(None).await;
+-            } else {
+-                let _ = shutdown_rx.await;
+-                return;
+-            }
++                    eprintln!(
++                        "[ws test server +{}ms] connection={} sending batch_size={} event_types={:?} audio_data={:?}",
++                        start.elapsed().as_millis(),
++                        connection_index,
++                        request_events.len(),
++                        request_events
++                            .iter()
++                            .map(|event| event.get("type").and_then(Value::as_str))
++                            .collect::<Vec<_>>(),
++                        request_events
++                            .iter()
++                            .find_map(|event| event.get("delta").and_then(Value::as_str)),
++                    );
++                    for event in &request_events {
++                        let Ok(payload) = serde_json::to_string(event) else {
++                            continue;
++                        };
++                        if ws_stream.send(Message::Text(payload.into())).await.is_err() {
++                            break;
++                        }
++                    }
++                }
+ 
+-            if connections.lock().unwrap().is_empty() {
+-                return;
+-            }
++                if close_after_requests {
++                    let _ = ws_stream.close(None).await;
++                } else if !shutdown_state.load(Ordering::SeqCst) {
++                    while !*shutdown_watch.borrow() {
++                        if shutdown_watch.changed().await.is_err() {
++                            break;
++                        }
++                    }
++                }
++            });
+         }
++
++        while connection_tasks.join_next().await.is_some() {}
+     });
+ 
+     WebSocketTestServer {
+diff --git a/codex-rs/core/tests/suite/client_websockets.rs b/codex-rs/core/tests/suite/client_websockets.rs
+index 796b85c..de8a34b 100755
+--- a/codex-rs/core/tests/suite/client_websockets.rs
++++ b/codex-rs/core/tests/suite/client_websockets.rs
+@@ -1,6 +1,7 @@
+ #![allow(clippy::expect_used, clippy::unwrap_used)]
+ use codex_api::WS_REQUEST_HEADER_TRACEPARENT_CLIENT_METADATA_KEY;
+ use codex_api::WS_REQUEST_HEADER_TRACESTATE_CLIENT_METADATA_KEY;
++use codex_config::types::AuthCredentialsStoreMode;
+ use codex_core::ModelClient;
+ use codex_core::ModelClientSession;
+ use codex_core::Prompt;
+@@ -46,6 +47,8 @@ use futures::StreamExt;
+ use opentelemetry_sdk::metrics::InMemoryMetricExporter;
+ use pretty_assertions::assert_eq;
+ use serde_json::json;
++use std::path::Path;
++use std::path::PathBuf;
+ use std::sync::Arc;
+ use std::time::Duration;
+ use tempfile::TempDir;
+@@ -87,6 +90,7 @@ fn assert_request_trace_matches(body: &serde_json::Value, expected_trace: &W3cTr
+ 
+ struct WebsocketTestHarness {
+     _codex_home: TempDir,
++    codex_home_path: PathBuf,
+     client: ModelClient,
+     session_id: SessionId,
+     thread_id: ThreadId,
+@@ -96,6 +100,46 @@ struct WebsocketTestHarness {
+     session_telemetry: SessionTelemetry,
+ }
+ 
++#[expect(clippy::unwrap_used)]
++fn write_chatgpt_auth_json(codex_home: &Path, access_token: &str, account_id: &str) {
++    use base64::Engine as _;
++
++    let header = json!({ "alg": "none", "typ": "JWT" });
++    let payload = json!({
++        "email": "user@example.com",
++        "https://api.openai.com/auth": {
++            "chatgpt_plan_type": "plus",
++            "chatgpt_account_id": account_id,
++        }
++    });
++
++    let b64 = |bytes: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
++    let fake_jwt = format!(
++        "{}.{}.{}",
++        b64(&serde_json::to_vec(&header).unwrap()),
++        b64(&serde_json::to_vec(&payload).unwrap()),
++        b64(b"sig")
++    );
++
++    let auth_json = json!({
++        "auth_mode": "chatgpt",
++        "OPENAI_API_KEY": null,
++        "tokens": {
++            "id_token": fake_jwt,
++            "access_token": access_token,
++            "refresh_token": "refresh-test",
++            "account_id": account_id,
++        },
++        "last_refresh": chrono::Utc::now(),
++    });
++
++    std::fs::write(
++        codex_home.join("auth.json"),
++        serde_json::to_string_pretty(&auth_json).unwrap(),
++    )
++    .unwrap();
++}
++
+ #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+ async fn responses_websocket_streams_request() {
+     skip_if_no_network!();
+@@ -479,6 +523,75 @@ async fn responses_websocket_reuses_connection_after_session_drop() {
+     server.shutdown().await;
+ }
+ 
++#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
++async fn responses_websocket_reconnects_when_auth_snapshot_changes_between_turns() {
++    skip_if_no_network!();
++
++    let server = start_websocket_server_with_headers(vec![
++        WebSocketConnectionConfig {
++            requests: vec![
++                vec![ev_response_created("resp-1"), ev_completed("resp-1")],
++                vec![
++                    ev_response_created("resp-reused"),
++                    ev_completed("resp-reused"),
++                ],
++            ],
++            response_headers: Vec::new(),
++            accept_delay: None,
++            close_after_requests: false,
++        },
++        WebSocketConnectionConfig {
++            requests: vec![vec![ev_response_created("resp-2"), ev_completed("resp-2")]],
++            response_headers: Vec::new(),
++            accept_delay: None,
++            close_after_requests: false,
++        },
++    ])
++    .await;
++
++    let harness = authenticated_websocket_harness(&server).await;
++    let prompt_one = prompt_with_input(vec![message_item("hello")]);
++    let prompt_two = prompt_with_input(vec![message_item("switched")]);
++
++    let mut first_turn = harness.client.new_session();
++    tokio::time::timeout(
++        Duration::from_secs(5),
++        stream_until_complete(&mut first_turn, &harness, &prompt_one),
++    )
++    .await
++    .expect("first authenticated websocket turn timed out");
++    assert!(
++        server.wait_for_handshakes(1, Duration::from_secs(1)).await,
++        "expected first websocket handshake",
++    );
++
++    write_chatgpt_auth_json(&harness.codex_home_path, "token-two", "acc-two");
++
++    let mut second_turn = harness.client.new_session();
++    tokio::time::timeout(
++        Duration::from_secs(5),
++        stream_until_complete(&mut second_turn, &harness, &prompt_two),
++    )
++    .await
++    .expect("second authenticated websocket turn timed out");
++    assert!(
++        server.wait_for_handshakes(2, Duration::from_secs(1)).await,
++        "expected websocket reconnect after auth snapshot change",
++    );
++
++    assert_eq!(server.handshakes().len(), 2);
++    assert_eq!(
++        server.handshakes()[0].header("authorization").as_deref(),
++        Some("Bearer token-one")
++    );
++    assert_eq!(
++        server.handshakes()[1].header("authorization").as_deref(),
++        Some("Bearer token-two")
++    );
++
++    server.shutdown().await;
++}
++
+ #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+ async fn responses_websocket_preconnect_is_reused_even_with_header_changes() {
+     skip_if_no_network!();
+@@ -1858,6 +1971,12 @@ fn websocket_provider(server: &WebSocketTestServer) -> ModelProviderInfo {
+     websocket_provider_with_connect_timeout(server, /*websocket_connect_timeout_ms*/ None)
+ }
+ 
++fn authenticated_websocket_provider(server: &WebSocketTestServer) -> ModelProviderInfo {
++    let mut provider = websocket_provider(server);
++    provider.requires_openai_auth = true;
++    provider
++}
++
+ fn websocket_provider_with_connect_timeout(
+     server: &WebSocketTestServer,
+     websocket_connect_timeout_ms: Option<u64>,
+@@ -1913,7 +2032,33 @@ async fn websocket_harness_with_provider_options(
+     provider: ModelProviderInfo,
+     runtime_metrics_enabled: bool,
+ ) -> WebsocketTestHarness {
++    websocket_harness_with_provider_options_and_home(
++        provider,
++        runtime_metrics_enabled,
++        TempDir::new().unwrap(),
++        /*use_auth_from_home*/ false,
++    )
++    .await
++}
++
++async fn authenticated_websocket_harness(server: &WebSocketTestServer) -> WebsocketTestHarness {
+     let codex_home = TempDir::new().unwrap();
++    write_chatgpt_auth_json(codex_home.path(), "token-one", "acc-one");
++    websocket_harness_with_provider_options_and_home(
++        authenticated_websocket_provider(server),
++        /*runtime_metrics_enabled*/ false,
++        codex_home,
++        /*use_auth_from_home*/ true,
++    )
++    .await
++}
++
++async fn websocket_harness_with_provider_options_and_home(
++    provider: ModelProviderInfo,
++    runtime_metrics_enabled: bool,
++    codex_home: TempDir,
++    use_auth_from_home: bool,
++) -> WebsocketTestHarness {
+     let mut config = load_default_config_for_test(&codex_home).await;
+     config.model = Some(MODEL.to_string());
+     if runtime_metrics_enabled {
+@@ -1926,8 +2071,25 @@ async fn websocket_harness_with_provider_options(
+     let model_info = codex_core::test_support::construct_model_info_offline(MODEL, &config);
+     let thread_id = ThreadId::new();
+     let session_id = SessionId::new();
+-    let auth_manager =
+-        codex_core::test_support::auth_manager_from_auth(CodexAuth::from_api_key("Test API Key"));
++    let auth_manager = if use_auth_from_home {
++        let auth = match CodexAuth::from_auth_storage(
++            codex_home.path(),
++            AuthCredentialsStoreMode::File,
++            /*chatgpt_base_url*/ None,
++        )
++        .await
++        {
++            Ok(Some(auth)) => auth,
++            Ok(None) => panic!("No CodexAuth found in codex_home"),
++            Err(err) => panic!("Failed to load auth from codex_home: {err}"),
++        };
++        codex_core::test_support::auth_manager_from_auth_with_home(
++            auth,
++            codex_home.path().to_path_buf(),
++        )
++    } else {
++        codex_core::test_support::auth_manager_from_auth(CodexAuth::from_api_key("Test API Key"))
++    };
+     let exporter = InMemoryMetricExporter::default();
+     let metrics = MetricsClient::new(
+         MetricsConfig::in_memory("test", "codex-core", env!("CARGO_PKG_VERSION"), exporter)
+@@ -1949,8 +2111,9 @@ async fn websocket_harness_with_provider_options(
+     .with_metrics(metrics);
+     let effort = None;
+     let summary = ReasoningSummary::Auto;
++    let codex_home_path = codex_home.path().to_path_buf();
+     let client = ModelClient::new(
+-        /*auth_manager*/ None,
++        /*auth_manager*/ use_auth_from_home.then_some(auth_manager.clone()),
+         session_id,
+         thread_id,
+         /*installation_id*/ TEST_INSTALLATION_ID.to_string(),
+@@ -1964,6 +2127,7 @@ async fn websocket_harness_with_provider_options(
+ 
+     WebsocketTestHarness {
+         _codex_home: codex_home,
++        codex_home_path,
+         client,
+         session_id,
+         thread_id,

--- a/src/lib/maintained-patch.js
+++ b/src/lib/maintained-patch.js
@@ -6,9 +6,11 @@ const CLIENT_RELATIVE_PATH = path.join("codex-rs", "core", "src", "client.rs");
 const TEST_SUITE_MOD_RELATIVE_PATH = path.join("codex-rs", "core", "tests", "suite", "mod.rs");
 const TEST_BINARY_SUPPORT_RELATIVE_PATH = path.join("codex-rs", "test-binary-support", "lib.rs");
 const TEST_FALLBACK_PATCHES = [
-  path.join("patches", "codex-hot-reload-tests.patch"),
-  path.join("patches", "codex-hot-reload-tests-0.122.patch"),
+  path.join("patches", "codex-hot-reload-tests-0.129.patch"),
+  path.join("patches", "codex-hot-reload-tests-0.128.patch"),
   path.join("patches", "codex-hot-reload-tests-0.124.patch"),
+  path.join("patches", "codex-hot-reload-tests-0.122.patch"),
+  path.join("patches", "codex-hot-reload-tests.patch"),
 ];
 
 const CLIENT_RUNTIME_REWRITES = [

--- a/src/lib/maintained-patch.js
+++ b/src/lib/maintained-patch.js
@@ -100,7 +100,7 @@ fn auth_connection_key(auth: Option<&CodexAuth>) -> Option<AuthConnectionKey> {
         let (auth, auth_connection_changed) = match self.state.auth_manager.as_ref() {
             Some(manager) => {
                 let cached_before_reload = auth_connection_key(manager.auth_cached().as_ref());
-                manager.reload();
+                manager.reload().await;
                 let auth = manager.auth().await;
                 let auth_connection_changed =
                     cached_before_reload != auth_connection_key(auth.as_ref());
@@ -139,7 +139,7 @@ fn auth_connection_key(auth: Option<&CodexAuth>) -> Option<AuthConnectionKey> {
         let (auth, auth_connection_changed) = match auth_manager.as_ref() {
             Some(manager) => {
                 let cached_before_reload = auth_connection_key(manager.auth_cached().as_ref());
-                manager.reload();
+                manager.reload().await;
                 let auth = self.state.provider.auth().await;
                 let auth_connection_changed =
                     cached_before_reload != auth_connection_key(auth.as_ref());
@@ -214,7 +214,7 @@ fn auth_connection_key(auth: Option<&CodexAuth>) -> Option<AuthConnectionKey> {
         let (auth, auth_connection_changed) = match auth_manager.as_ref() {
             Some(manager) => {
                 let cached_before_reload = auth_connection_key(manager.auth_cached().as_ref());
-                manager.reload();
+                manager.reload().await;
                 let auth = self.state.provider.auth().await;
                 let auth_connection_changed =
                     cached_before_reload != auth_connection_key(auth.as_ref());

--- a/test/maintained-patch.test.js
+++ b/test/maintained-patch.test.js
@@ -113,7 +113,7 @@ test("applyClientRuntimeRewrites patches the runtime hot-reload changes and is i
   assert.equal(first.steps.every((step) => step.status === "applied"), true);
   assert.match(first.text, /auth_connection_changed: bool,/);
   assert.match(first.text, /fn auth_connection_key\(auth: Option<&CodexAuth>\)/);
-  assert.match(first.text, /manager\.reload\(\);/);
+  assert.match(first.text, /manager\.reload\(\)\.await;/);
   assert.match(first.text, /if client_setup\.auth_connection_changed \{/);
   assert.match(first.text, /_ if auth_connection_changed => true,/);
   assert.match(first.text, /auth_connection_changed: client_setup\.auth_connection_changed,/);
@@ -266,7 +266,7 @@ test("applyClientRuntimeRewrites patches the upstream 0.122 runtime layout and i
   assert.equal(first.steps.every((step) => step.status === "applied"), true);
   assert.match(first.text, /auth_connection_changed: bool,/);
   assert.match(first.text, /let \(auth, auth_connection_changed\) = match auth_manager\.as_ref\(\)/);
-  assert.match(first.text, /manager\.reload\(\);/);
+  assert.match(first.text, /manager\.reload\(\)\.await;/);
   assert.match(first.text, /None => \(self\.state\.provider\.auth\(\)\.await, false\),/);
   assert.match(first.text, /if client_setup\.auth_connection_changed \{/);
   assert.match(first.text, /auth_connection_changed: client_setup\.auth_connection_changed,/);
@@ -379,7 +379,7 @@ test("applyClientRuntimeRewrites patches the upstream 0.124 runtime layout and i
   assert.equal(first.steps.every((step) => step.status === "applied"), true);
   assert.match(first.text, /auth_connection_changed: bool,/);
   assert.match(first.text, /let \(auth, auth_connection_changed\) = match auth_manager\.as_ref\(\)/);
-  assert.match(first.text, /manager\.reload\(\);/);
+  assert.match(first.text, /manager\.reload\(\)\.await;/);
   assert.match(first.text, /let api_auth = self\.state\.provider\.api_auth\(\)\.await\?;/);
   assert.match(first.text, /None => \(self\.state\.provider\.auth\(\)\.await, false\),/);
   assert.match(first.text, /if client_setup\.auth_connection_changed \{/);


### PR DESCRIPTION
## Summary
- add maintained fallback test patches for upstream Codex 0.128.0 and 0.129.0
- await auth reload in the maintained runtime rewrite so token changes are observed between turns
- update maintained patch tests to cover the awaited reload behavior

## Validation
- npm test
- compatibility-sweep.yml on fix/upstream-128-129-hotpatch for versions 0.128.0 and 0.129.0: https://github.com/minanagehsalalma/codex-multiaccount-patcher/actions/runs/25560530391

Closes #7
Closes #14